### PR TITLE
Refactor physical properties calculations

### DIFF
--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -81,6 +81,6 @@ jobs:
         with:
           name: ${{ matrix.os }}_artifacts.zip
           path: wheelhouse/*
-      #- name: Setup tmate
-      #  if: ${{ failure() }}
-      #  uses: mxschmitt/action-tmate@v3
+      - name: Setup tmate
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -81,6 +81,6 @@ jobs:
         with:
           name: ${{ matrix.os }}_artifacts.zip
           path: wheelhouse/*
-      - name: Setup tmate
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
+      #- name: Setup tmate
+      #  if: ${{ failure() }}
+      #  uses: mxschmitt/action-tmate@v3

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SINGLEION_SOURCES
     singleion/ic_socf.cpp
     singleion/ic_tensorops.cpp
     singleion/ic1ion.cpp
+    singleion/physprop.cpp
 )
 
 # Adds the source modules as object libraries

--- a/src/include/cf1ion.hpp
+++ b/src/include/cf1ion.hpp
@@ -15,14 +15,17 @@
 
 namespace libMcPhase {
 
-class cf1ion: public cfpars {
+class cf1ion: public cfpars, public physprop {
 
     protected:
         bool m_ham_calc = false;                              // Flag to indicate if Hamiltonian calculated
+        bool m_upper = true;                                  // Flag to indicate if upper triangle of Ham is calc
         bool m_ev_calc = false;                               // Flag to indicate if eigenvectors/values calculated
         RowMatrixXcd m_hamiltonian;                           // Cached Hamiltonian
         RowMatrixXcd m_eigenvectors;                          // Cached eigenvectors
         VectorXd m_eigenvalues;                               // Cached eigenvalues
+        RowMatrixXcd _hamiltonian(bool upper=true);
+        void fill_upper();
 
     public:
         // Setters
@@ -38,10 +41,10 @@ class cf1ion: public cfpars {
         cf1ion(const double J) : cfpars(J) {};
         cf1ion(const std::string &ionname) : cfpars(ionname) {};
         // Methods
-        RowMatrixXcd hamiltonian(bool upper=true);
+        RowMatrixXcd hamiltonian();
         std::tuple<RowMatrixXcd, VectorXd> eigensystem();
-        std::vector<double> calculate_boltzmann(VectorXd en, double T);
-        std::vector<double> heatcapacity(std::vector<double> Tvec);
+        RowMatrixXcd zeeman_hamiltonian(double H, std::vector<double> Hdir);
+        std::vector<RowMatrixXcd> calculate_moments_matrix(RowMatrixXcd ev);
 
 }; // class cf1ion
 

--- a/src/include/cf1ion.hpp
+++ b/src/include/cf1ion.hpp
@@ -25,12 +25,12 @@ class cf1ion: public cfpars {
 
     public:
         // Setters
-        virtual void set_unit(const Units newunit);
-        virtual void set_type(const Type newtype);
-        virtual void set_name(const std::string &ionname);
-        virtual void set_J(const double J);
-        virtual void set(const Blm blm, double val);
-        virtual void set(int l, int m, double val);
+        void set_unit(const Units newunit);
+        void set_type(const Type newtype);
+        void set_name(const std::string &ionname);
+        void set_J(const double J);
+        void set(const Blm blm, double val);
+        void set(int l, int m, double val);
         // Constructors
         cf1ion() : cfpars() {};
         cf1ion(const int J2) : cfpars(J2) {};

--- a/src/include/cf1ion.hpp
+++ b/src/include/cf1ion.hpp
@@ -11,6 +11,7 @@
 
 #include "eigen.hpp"
 #include "cfpars.hpp"
+#include "physprop.hpp"
 
 namespace libMcPhase {
 
@@ -39,6 +40,8 @@ class cf1ion: public cfpars {
         // Methods
         RowMatrixXcd hamiltonian(bool upper=true);
         std::tuple<RowMatrixXcd, VectorXd> eigensystem();
+        std::vector<double> calculate_boltzmann(VectorXd en, double T);
+        std::vector<double> heatcapacity(std::vector<double> Tvec);
 
 }; // class cf1ion
 

--- a/src/include/cf1ion.hpp
+++ b/src/include/cf1ion.hpp
@@ -21,10 +21,13 @@ class cf1ion: public cfpars, public physprop {
         bool m_ham_calc = false;                              // Flag to indicate if Hamiltonian calculated
         bool m_upper = true;                                  // Flag to indicate if upper triangle of Ham is calc
         bool m_ev_calc = false;                               // Flag to indicate if eigenvectors/values calculated
+        bool m_magops_calc = false;                           // Flag to indicate if magnetic operators calculated
         RowMatrixXcd m_hamiltonian;                           // Cached Hamiltonian
         RowMatrixXcd m_eigenvectors;                          // Cached eigenvectors
         VectorXd m_eigenvalues;                               // Cached eigenvalues
+        std::vector<RowMatrixXcd> m_magops;                   // Cached magnetic operators
         RowMatrixXcd _hamiltonian(bool upper=true);
+        void calc_mag_ops();
         void fill_upper();
 
     public:

--- a/src/include/cfpars.hpp
+++ b/src/include/cfpars.hpp
@@ -24,6 +24,9 @@
 
 namespace libMcPhase {
 
+// Conversion factors for different energy units[from][to], order: [meV, cm, K].
+static const std::array<double, 3> ENERGYCONV = { {1., 8.065544005, 11.6045221} };
+
 class cfpars {
 
     public:
@@ -34,7 +37,6 @@ class cfpars {
                     B44S = 5, B43S = 6, B42S = 7, B41S = 8, B40 = 9, B41 = 10, B42 = 11, B43 = 12, B44 = 13,
                     B66S = 14, B65S = 15, B64S = 16, B63S = 17, B62S = 18, B61S = 19, 
                     B60 = 20, B61 = 21, B62 = 22, B63 = 23, B64 = 24, B65 = 25, B66 = 26};
-    enum class MagUnits {bohr = 0, cgs = 1, SI = 2};
 
     protected:
         std::array<double, 27> m_Bi{};                        // Internal array of values (in Wybourne/theta_k in meV)

--- a/src/include/cfpars.hpp
+++ b/src/include/cfpars.hpp
@@ -24,11 +24,6 @@
 
 namespace libMcPhase {
 
-// Boltzmann constant and bohr magneton defined in cfpars.cpp and ic1ion.cpp because they depend on energy
-// and the default energy unit in cfpars is meV whilst in ic1ion it is cm
-static const double NAMUB = 5.5849397;         // N_A*mu_B - J/T/mol - product of Bohr magneton and Avogadro's number
-static const double GS = 2.0023193043622;      // The electron gyromagnetic ratio
-
 class cfpars {
 
     public:

--- a/src/include/cfpars.hpp
+++ b/src/include/cfpars.hpp
@@ -50,6 +50,7 @@ class cfpars {
         Type m_type = Type::Blm;                              // Type of crystal field parameters
         std::string m_ionname;                                // Name of ion
         int m_J2 = 0;                                         // 2*J == twice the total angular momentum
+        double m_GJ = -1.;                                    // Lande g-factor
         bool m_convertible = false;                           // True if can convert between types and normalisations
         racah m_racah{};                                      // Class to calc n-j symbols and cache factorials
         int m_n = 1;                                          // Number of open shell electrons in this configuration
@@ -58,21 +59,23 @@ class cfpars {
         // Methods
         virtual void getfromionname(const std::string &ionname);
         // Getters
-        const Units get_unit() const { return m_unit; }
-        const Normalisation get_normalisation() const { return m_norm; }
-        const Type get_type() const { return m_type; }
-        const std::string get_name() const { return m_ionname; }
-        const double get(const Blm blm) const { return m_Bo[(int)blm]; }
-        const double get(int l, int m) const;
-        const double alpha() { return m_stevfact[0]; }
-        const double beta() { return m_stevfact[1]; }
-        const double gamma() { return m_stevfact[2]; }
-        const double get_J() { return (double)(m_J2 / 2.); }
+        Units get_unit() const { return m_unit; }
+        Normalisation get_normalisation() const { return m_norm; }
+        Type get_type() const { return m_type; }
+        std::string get_name() const { return m_ionname; }
+        double get(const Blm blm) const { return m_Bo[(int)blm]; }
+        double get(int l, int m) const;
+        double get_GJ() const { return m_GJ; }
+        double alpha() const { return m_stevfact[0]; }
+        double beta() const { return m_stevfact[1]; }
+        double gamma() const { return m_stevfact[2]; }
+        double get_J() const { return (double)(m_J2 / 2.); }
         // Setters
         virtual void set_unit(const Units newunit);
         virtual void set_type(const Type newtype);
         virtual void set_name(const std::string &ionname);
         virtual void set_J(const double J);
+        virtual void set_GJ(const double GJ) { m_GJ = GJ; }
         virtual void set(const Blm blm, double val);
         virtual void set(int l, int m, double val);
         // Constructors

--- a/src/include/ic1ion.hpp
+++ b/src/include/ic1ion.hpp
@@ -13,6 +13,7 @@
 #define IC1ION_H
 
 #include "cfpars.hpp"
+#include "physprop.hpp"
 #include "eigen.hpp"
 #include "ic_states.hpp"
 #include <algorithm>
@@ -21,9 +22,7 @@
 
 namespace libMcPhase {
 
-// Declare K_B and MU_B in cm here (meV version declared in cfpars.cpp)
-static const double K_B = 0.6950348004;    // cm/K - Boltzmann constant
-static const double MU_B = 0.46686447783;  // cm/T - Bohr magneton
+static const double GS = 2.0023193043622;  // The electron gyromagnetic ratio
 
 struct pair_hash
 {

--- a/src/include/ic1ion.hpp
+++ b/src/include/ic1ion.hpp
@@ -18,7 +18,6 @@
 #include "ic_states.hpp"
 #include <algorithm>
 #include <vector>
-#include <unordered_map>
 
 namespace libMcPhase {
 

--- a/src/include/ic1ion.hpp
+++ b/src/include/ic1ion.hpp
@@ -32,7 +32,7 @@ struct pair_hash
     }
 };
 
-class ic1ion : public cfpars {
+class ic1ion : public cfpars, public physprop {
 
     public:
         enum class CoulombType { Slater = 0, CondonShortley = 1, Racah = 2 };
@@ -79,7 +79,6 @@ class ic1ion : public cfpars {
         void calculate_eigensystem();                          // Diagonalises the Hamiltonian
         // Declarations for functions in ic_tensoropts.cpp
         void calc_tensorops(int num);                          // Populates m_tensorops vector
-        std::vector< RowMatrixXcd > calculate_moments_matrix(RowMatrixXcd ev);
 
     public:
         // Setters
@@ -103,13 +102,9 @@ class ic1ion : public cfpars {
         // Methods
         RowMatrixXcd hamiltonian();
         std::tuple<RowMatrixXcd, VectorXd> eigensystem();
-        std::vector<double> magnetisation(std::vector<double> H, std::vector<double> Hdir, double T, MagUnits type);
-        std::vector<double> susceptibility(std::vector<double> T, std::vector<double> Hdir, MagUnits type);
         RowMatrixXcd zeeman_hamiltonian(double H,              // Calculates the Zeeman Hamiltonian for applied
             std::vector<double> Hdir);                         //   field H in direction Hdir
-        std::vector< std::vector<double> > calculate_moments(RowMatrixXcd ev);
-        std::vector<double> calculate_boltzmann(               // Calculates the Boltzmann factor exp(-E/kT)
-            VectorXd en, double T);
+        std::vector< RowMatrixXcd > calculate_moments_matrix(RowMatrixXcd ev);
         std::vector<fstates_t> get_states();
 
 }; // class ic1ion

--- a/src/include/ic1ion.hpp
+++ b/src/include/ic1ion.hpp
@@ -84,14 +84,14 @@ class ic1ion : public cfpars {
 
     public:
         // Setters
-        virtual void set_unit(const Units newunit);
-        virtual void set_type(const Type newtype);
-        virtual void set_name(const std::string &ionname);
-        virtual void set(const Blm blm, double val);
-        virtual void set(int l, int m, double val);
-        virtual void set_coulomb(std::vector<double> val, CoulombType type = CoulombType::Slater);
-        virtual void set_ci(std::vector<double> val);
-        virtual void set_spinorbit(double val, SpinOrbType type = SpinOrbType::Zeta);
+        void set_unit(const Units newunit);
+        void set_type(const Type newtype);
+        void set_name(const std::string &ionname);
+        void set(const Blm blm, double val);
+        void set(int l, int m, double val);
+        void set_coulomb(std::vector<double> val, CoulombType type = CoulombType::Slater);
+        void set_ci(std::vector<double> val);
+        void set_spinorbit(double val, SpinOrbType type = SpinOrbType::Zeta);
         // Getters
         std::array<double, 4> get_coulomb() const { return m_F; };
         double get_spinorbit() const { return m_xi; };

--- a/src/include/ic_states.hpp
+++ b/src/include/ic_states.hpp
@@ -72,7 +72,7 @@ class qR7
 
       // Other member functions //
       int set(int w1_, int w2_, int w3_);					// Set value
-      bool isequal (const char * Wstr);						// (isequal to string)
+      bool isequal (int w);
 
       // Overloaded operators //
       bool operator == (const qR7 & wp) const;					// (isequal)
@@ -102,7 +102,7 @@ class qG2
 
       // Other member functions //
       int set(int u1_, int u2_);						// Set value
-      bool isequal (const char * Ustr);						// (isequal to string)
+      bool isequal (int u);
 
       // Overloaded operators //
       bool operator == (const qG2 & up) const;					// (isequal)

--- a/src/include/physprop.hpp
+++ b/src/include/physprop.hpp
@@ -59,7 +59,7 @@ class physprop {
       //std::vector< std::vector<double> > calculate_moments(RowMatrixXcd ev);
         std::vector<double> calculate_boltzmann(VectorXd en, double T);
         std::vector<double> heatcapacity(std::vector<double> Tvec);
-        std::vector<double> magnetisation(std::vector<double> H, std::vector<double> Hdir, double T, MagUnits type);
+        std::vector< std::vector<double> > magnetisation(std::vector<double> H, std::vector<double> Hdir, std::vector<double> Tvec, MagUnits type);
         std::vector<double> susceptibility(std::vector<double> T, std::vector<double> Hdir, MagUnits type);
 };
 

--- a/src/include/physprop.hpp
+++ b/src/include/physprop.hpp
@@ -56,11 +56,10 @@ class physprop {
         virtual RowMatrixXcd zeeman_hamiltonian(double H, std::vector<double> Hdir) = 0;
         virtual std::tuple<RowMatrixXcd, VectorXd> eigensystem() = 0;
         virtual std::vector<RowMatrixXcd> calculate_moments_matrix(RowMatrixXcd ev) = 0;
-      //std::vector< std::vector<double> > calculate_moments(RowMatrixXcd ev);
-        std::vector<double> calculate_boltzmann(VectorXd en, double T);
-        std::vector<double> heatcapacity(std::vector<double> Tvec);
-        std::vector< std::vector<double> > magnetisation(std::vector<double> H, std::vector<double> Hdir, std::vector<double> Tvec, MagUnits type);
-        std::vector<double> susceptibility(std::vector<double> T, std::vector<double> Hdir, MagUnits type);
+        VectorXd calculate_boltzmann(VectorXd en, double T);
+        VectorXd heatcapacity(std::vector<double> Tvec);
+        RowMatrixXd magnetisation(std::vector<double> H, std::vector<double> Hdir, std::vector<double> Tvec, MagUnits type);
+        VectorXd susceptibility(std::vector<double> T, std::vector<double> Hdir, MagUnits type);
 };
 
 // Mapping for Python binding to map string to enum

--- a/src/include/physprop.hpp
+++ b/src/include/physprop.hpp
@@ -1,0 +1,37 @@
+/* physprop.hpp
+ *
+ * Header file for the physical properties base class
+ *
+ * (c) 2024 Duc Le - duc.le@stfc.ac.uk
+ * This program is licensed under the GNU General Purpose License, version 3. Please see the COPYING file
+ */
+
+#pragma once
+
+namespace libMcPhase {
+
+// Basic physical constants (needs cm constants as internal energy units in ic1ion is cm)
+static const double K_B = 0.08617343183;       // meV/K - Boltzmann constant
+static const double MU_B = 0.0578838263;       // meV/T - Bohr magneton
+static const double K_Bc = 0.6950348004;       // cm/K - Boltzmann constant^M
+static const double MU_Bc = 0.46686447783;     // cm/T - Bohr magneton^M
+
+// Conversion factors for different magnetic units for magnetisation. Order: [bohr, cgs, SI].
+// NAMUB is N_A * MU_B in J/T/mol == Am^2/mol is the SI unit. 
+// The cgs unit is N_A * MU_B in erg/G/mol == emu/mol is different only by a factor of 1000 larger
+static const double NAMUB = 5.5849397;  // N_A*mu_B - J/T/mol - product of Bohr magneton and Avogadro's number
+static const std::array<double, 3> MAGCONV = {1., NAMUB*1000, NAMUB};
+
+// Note these constants are strange because the default energy unit in this module is cm-1
+static const double NAMUBSQ_ERG = 0.26074098;     // N_A * muB[erg/G] * muB[cm/T] * [Tesla_to_Gauss=1e-4]
+static const double NAMUBSQ_JOULE = 3.276568e-06; // N_A * muB[J/T] * muB[cm/T] * mu0
+// Factor of mu0 is needed in SI due to different definition of the magnetisation, B and H fields
+
+// Conversion factors for different magnetic units for magnetic susceptibility. Order: [bohr, cgs, SI].
+// The susceptibility prefactor is (in principle) N_A * MU_B^2 but we need to account for various units...
+// The atomic (bohr) susceptibility is in uB/T/ion; cgs is in erg/G^2/mol==cm^3/mol; SI in J/T^2/mol==m^3/mol
+// Note that chi_SI = (4pi*10^-6)chi_cgs [*not* 4pi*10-7!]
+static const std::array<double, 3> SUSCCONV = {MU_B, NAMUBSQ_ERG, NAMUBSQ_JOULE};
+
+
+} // namespace libMcPhase

--- a/src/include/physprop.hpp
+++ b/src/include/physprop.hpp
@@ -10,6 +10,7 @@
 
 #include "eigen.hpp"
 #include <vector>
+#include <unordered_map>
 
 namespace libMcPhase {
 
@@ -26,8 +27,10 @@ static const double NAMUB = 5.5849397;  // N_A*mu_B - J/T/mol - product of Bohr 
 static const std::array<double, 3> MAGCONV = {1., NAMUB*1000, NAMUB};
 
 // Note these constants are strange because the default energy unit in this module is cm-1
-static const double NAMUBSQ_ERG = 0.26074098;     // N_A * muB[erg/G] * muB[cm/T] * [Tesla_to_Gauss=1e-4]
-static const double NAMUBSQ_JOULE = 3.276568e-06; // N_A * muB[J/T] * muB[cm/T] * mu0
+static const double NAMUBSQc_ERG = 0.26074098;     // N_A * muB[erg/G] * muB[cm/T] * [Tesla_to_Gauss=1e-4]
+static const double NAMUBSQc_JOULE = 3.276568e-06; // N_A * muB[J/T] * muB[cm/T] * mu0
+static const double NAMUBSQ_ERG = 0.03232776;      // N_A * muB[erg/G] * muB[meV/T] * [Tesla_to_Gauss=1e-4]
+static const double NAMUBSQ_JOULE = 4.062426e-07;  // N_A * muB[J/T] * muB[meV/T] * mu0
 // Factor of mu0 is needed in SI due to different definition of the magnetisation, B and H fields
 
 // Conversion factors for different magnetic units for magnetic susceptibility. Order: [bohr, cgs, SI].
@@ -53,11 +56,15 @@ class physprop {
         virtual RowMatrixXcd zeeman_hamiltonian(double H, std::vector<double> Hdir) = 0;
         virtual std::tuple<RowMatrixXcd, VectorXd> eigensystem() = 0;
         virtual std::vector<RowMatrixXcd> calculate_moments_matrix(RowMatrixXcd ev) = 0;
-        std::vector< std::vector<double> > calculate_moments(RowMatrixXcd ev);
+      //std::vector< std::vector<double> > calculate_moments(RowMatrixXcd ev);
         std::vector<double> calculate_boltzmann(VectorXd en, double T);
         std::vector<double> heatcapacity(std::vector<double> Tvec);
         std::vector<double> magnetisation(std::vector<double> H, std::vector<double> Hdir, double T, MagUnits type);
         std::vector<double> susceptibility(std::vector<double> T, std::vector<double> Hdir, MagUnits type);
 };
+
+// Mapping for Python binding to map string to enum
+static const std::unordered_map<std::string, physprop::MagUnits> mag_unit_names = {
+    {"bohr", physprop::MagUnits::bohr}, {"cgs", physprop::MagUnits::cgs}, {"SI", physprop::MagUnits::SI} };
 
 } // namespace libMcPhase

--- a/src/include/physprop.hpp
+++ b/src/include/physprop.hpp
@@ -8,6 +8,9 @@
 
 #pragma once
 
+#include "eigen.hpp"
+#include <vector>
+
 namespace libMcPhase {
 
 // Basic physical constants (needs cm constants as internal energy units in ic1ion is cm)
@@ -38,5 +41,23 @@ static const double NAMEV = 96.48533212;          // J/mol = N_A * meV
 
 // EPSILON to determine if energy levels are degenerate or not
 static const double DELTA_EPS = 1e-6;
+
+// Base class for physical properties calculations. Must derive and implement zeeman_hamiltonian
+class physprop {
+    protected:
+        double m_meVconv = 1.0;   // Conversion factor from user energy units to meV
+
+    public:
+        enum class MagUnits {bohr = 0, cgs = 1, SI = 2};
+        virtual RowMatrixXcd hamiltonian() = 0;
+        virtual RowMatrixXcd zeeman_hamiltonian(double H, std::vector<double> Hdir) = 0;
+        virtual std::tuple<RowMatrixXcd, VectorXd> eigensystem() = 0;
+        virtual std::vector<RowMatrixXcd> calculate_moments_matrix(RowMatrixXcd ev) = 0;
+        std::vector< std::vector<double> > calculate_moments(RowMatrixXcd ev);
+        std::vector<double> calculate_boltzmann(VectorXd en, double T);
+        std::vector<double> heatcapacity(std::vector<double> Tvec);
+        std::vector<double> magnetisation(std::vector<double> H, std::vector<double> Hdir, double T, MagUnits type);
+        std::vector<double> susceptibility(std::vector<double> T, std::vector<double> Hdir, MagUnits type);
+};
 
 } // namespace libMcPhase

--- a/src/include/physprop.hpp
+++ b/src/include/physprop.hpp
@@ -13,8 +13,8 @@ namespace libMcPhase {
 // Basic physical constants (needs cm constants as internal energy units in ic1ion is cm)
 static const double K_B = 0.08617343183;       // meV/K - Boltzmann constant
 static const double MU_B = 0.0578838263;       // meV/T - Bohr magneton
-static const double K_Bc = 0.6950348004;       // cm/K - Boltzmann constant^M
-static const double MU_Bc = 0.46686447783;     // cm/T - Bohr magneton^M
+static const double K_Bc = 0.6950348004;       // cm/K - Boltzmann constant
+static const double MU_Bc = 0.46686447783;     // cm/T - Bohr magneton
 
 // Conversion factors for different magnetic units for magnetisation. Order: [bohr, cgs, SI].
 // NAMUB is N_A * MU_B in J/T/mol == Am^2/mol is the SI unit. 
@@ -33,5 +33,10 @@ static const double NAMUBSQ_JOULE = 3.276568e-06; // N_A * muB[J/T] * muB[cm/T] 
 // Note that chi_SI = (4pi*10^-6)chi_cgs [*not* 4pi*10-7!]
 static const std::array<double, 3> SUSCCONV = {MU_B, NAMUBSQ_ERG, NAMUBSQ_JOULE};
 
+// Conversion factor for heat capacity calculations
+static const double NAMEV = 96.48533212;          // J/mol = N_A * meV
+
+// EPSILON to determine if energy levels are degenerate or not
+static const double DELTA_EPS = 1e-6;
 
 } // namespace libMcPhase

--- a/src/libmcphase/pycf1ion.cpp
+++ b/src/libmcphase/pycf1ion.cpp
@@ -9,6 +9,7 @@
 #include "cf1ion.hpp"
 #include <pybind11/pybind11.h>
 #include <pybind11/eigen.h>
+#include <pybind11/stl.h>
 #include "pycfpars.hpp"
 
 namespace py = pybind11;
@@ -30,7 +31,8 @@ void wrap_cf1ion(py::module &m) {
         .def(py::init<const double &>(), py::arg("J"))
         .def(py::init(&cf1ion_init), cfpars_init_str)
         .def("hamiltonian", &cf1ion::hamiltonian, "the crystal field Hamiltonian", "upper"_a=true)
-        .def("eigensystem", &cf1ion::eigensystem, "the eigenvectors and eigenvalues of the crystal field Hamiltonian");
+        .def("eigensystem", &cf1ion::eigensystem, "the eigenvectors and eigenvalues of the crystal field Hamiltonian")
+        .def("heatcapacity", &cf1ion::heatcapacity, "the heat capacity of the crystal field Hamiltonian in J/mol/K");
 }
 
 

--- a/src/libmcphase/pycf1ion.cpp
+++ b/src/libmcphase/pycf1ion.cpp
@@ -30,9 +30,16 @@ void wrap_cf1ion(py::module &m) {
         .def(py::init<const std::string &>(), py::arg("ionname"))
         .def(py::init<const double &>(), py::arg("J"))
         .def(py::init(&cf1ion_init), cfpars_init_str)
+        .def_property("GJ", [](cf1ion const &self) { return self.get_GJ(); }, [](cf1ion &self, double v) { self.set_GJ(v); })
         .def("hamiltonian", &cf1ion::hamiltonian, "the crystal field Hamiltonian")
         .def("eigensystem", &cf1ion::eigensystem, "the eigenvectors and eigenvalues of the crystal field Hamiltonian")
-        .def("heatcapacity", &cf1ion::heatcapacity, "the heat capacity of the crystal field Hamiltonian in J/mol/K");
+        .def("zeeman_hamiltonian", &cf1ion::zeeman_hamiltonian, "the Zeeman Hamiltonian")
+        .def("calculate_boltzmann", &cf1ion::calculate_boltzmann, "")
+        .def("heatcapacity", &cf1ion::heatcapacity, "the heat capacity of the crystal field Hamiltonian in J/mol/K")
+        .def("magnetisation", [](cf1ion &self, std::vector<double> H, std::vector<double> Hdir, double T, std::string unit) { return self.magnetisation(H, Hdir, T,
+             set_enum(unit, mag_unit_names, "Invalid magnetic unit, must be one of: 'bohr', 'cgs', or 'SI'")); })
+        .def("susceptibility", [](cf1ion &self, std::vector<double> T, std::vector<double> Hdir, std::string unit) { return self.susceptibility(T, Hdir,
+             set_enum(unit, mag_unit_names, "Invalid magnetic unit, must be one of: 'bohr', 'cgs', or 'SI'")); });
 }
 
 

--- a/src/libmcphase/pycf1ion.cpp
+++ b/src/libmcphase/pycf1ion.cpp
@@ -36,7 +36,7 @@ void wrap_cf1ion(py::module &m) {
         .def("zeeman_hamiltonian", &cf1ion::zeeman_hamiltonian, "the Zeeman Hamiltonian")
         .def("calculate_boltzmann", &cf1ion::calculate_boltzmann, "")
         .def("heatcapacity", &cf1ion::heatcapacity, "the heat capacity of the crystal field Hamiltonian in J/mol/K")
-        .def("magnetisation", [](cf1ion &self, std::vector<double> H, std::vector<double> Hdir, double T, std::string unit) { return self.magnetisation(H, Hdir, T,
+        .def("magnetisation", [](cf1ion &self, std::vector<double> H, std::vector<double> Hdir, std::vector<double> T, std::string unit) { return self.magnetisation(H, Hdir, T,
              set_enum(unit, mag_unit_names, "Invalid magnetic unit, must be one of: 'bohr', 'cgs', or 'SI'")); })
         .def("susceptibility", [](cf1ion &self, std::vector<double> T, std::vector<double> Hdir, std::string unit) { return self.susceptibility(T, Hdir,
              set_enum(unit, mag_unit_names, "Invalid magnetic unit, must be one of: 'bohr', 'cgs', or 'SI'")); });

--- a/src/libmcphase/pycf1ion.cpp
+++ b/src/libmcphase/pycf1ion.cpp
@@ -30,7 +30,7 @@ void wrap_cf1ion(py::module &m) {
         .def(py::init<const std::string &>(), py::arg("ionname"))
         .def(py::init<const double &>(), py::arg("J"))
         .def(py::init(&cf1ion_init), cfpars_init_str)
-        .def("hamiltonian", &cf1ion::hamiltonian, "the crystal field Hamiltonian", "upper"_a=true)
+        .def("hamiltonian", &cf1ion::hamiltonian, "the crystal field Hamiltonian")
         .def("eigensystem", &cf1ion::eigensystem, "the eigenvectors and eigenvalues of the crystal field Hamiltonian")
         .def("heatcapacity", &cf1ion::heatcapacity, "the heat capacity of the crystal field Hamiltonian in J/mol/K");
 }

--- a/src/libmcphase/pycf1ion.cpp
+++ b/src/libmcphase/pycf1ion.cpp
@@ -15,8 +15,6 @@ namespace py = pybind11;
 using namespace libMcPhase;
 using namespace pybind11::literals;
 
-void cf_parse(cfpars *cls, py::args args, py::kwargs kwargs);
-
 cf1ion *cf1ion_init(py::args args, py::kwargs kwargs) {
     cf1ion *cls = new cf1ion;
     cf_parse(static_cast<cfpars*>(cls), args, kwargs);

--- a/src/libmcphase/pycfpars.hpp
+++ b/src/libmcphase/pycfpars.hpp
@@ -8,6 +8,11 @@
 
 #pragma once
 
+#include "cfpars.hpp"
+#include <pybind11/pybind11.h>
+namespace py = pybind11;
+using namespace libMcPhase;
+
 template <typename T> T set_enum(std::string key, std::unordered_map<std::string, T> enum_map, std::string errmsg) {
     auto it = enum_map.find(key);
     if (it == enum_map.end()) {
@@ -27,3 +32,4 @@ static const char* cfpars_init_str = "Construct a cfpars object\n"
                                      "               see online documentation or McPhase webpage for definitions\n"
                                      "        Blm - value of parameters, e.g. cfp = cfpars('Pr3+', B20=0.1, B22=-0.01, B40=0.001)\n";
 
+void cf_parse(cfpars *cls, py::args args, py::kwargs kwargs, bool is_ic1ion=false);

--- a/src/libmcphase/pyic1ion.cpp
+++ b/src/libmcphase/pyic1ion.cpp
@@ -58,7 +58,7 @@ void wrap_ic1ion(py::module &m) {
         .def("zeeman_hamiltonian", &ic1ion::zeeman_hamiltonian, "the Zeeman Hamiltonian")
         .def("calculate_boltzmann", &ic1ion::calculate_boltzmann, "")
         .def("heatcapacity", &ic1ion::heatcapacity, "the heat capacity of the crystal field Hamiltonian in J/mol/K")
-        .def("magnetisation", [](ic1ion &self, std::vector<double> H, std::vector<double> Hdir, double T, std::string unit) { return self.magnetisation(H, Hdir, T,
+        .def("magnetisation", [](ic1ion &self, std::vector<double> H, std::vector<double> Hdir, std::vector<double> T, std::string unit) { return self.magnetisation(H, Hdir, T,
              set_enum(unit, mag_unit_names, "Invalid magnetic unit, must be one of: 'bohr', 'cgs', or 'SI'")); })
         .def("susceptibility", [](ic1ion &self, std::vector<double> T, std::vector<double> Hdir, std::string unit) { return self.susceptibility(T, Hdir,
              set_enum(unit, mag_unit_names, "Invalid magnetic unit, must be one of: 'bohr', 'cgs', or 'SI'")); })

--- a/src/libmcphase/pyic1ion.cpp
+++ b/src/libmcphase/pyic1ion.cpp
@@ -15,8 +15,8 @@
 namespace py = pybind11;
 using namespace libMcPhase;
 
-static const std::unordered_map<std::string, cfpars::MagUnits> mag_unit_names = {
-    {"bohr", cfpars::MagUnits::bohr}, {"cgs", cfpars::MagUnits::cgs}, {"SI", cfpars::MagUnits::SI} };
+static const std::unordered_map<std::string, physprop::MagUnits> mag_unit_names = {
+    {"bohr", physprop::MagUnits::bohr}, {"cgs", physprop::MagUnits::cgs}, {"SI", physprop::MagUnits::SI} };
 
 static const std::unordered_map<std::string, ic1ion::CoulombType> coulomb_names = {
     {"Slater", ic1ion::CoulombType::Slater}, {"CondonShortley", ic1ion::CoulombType::CondonShortley}, {"Racah", ic1ion::CoulombType::Racah} };
@@ -59,6 +59,7 @@ void wrap_ic1ion(py::module &m) {
         .def("zeeman_hamiltonian", &ic1ion::zeeman_hamiltonian, "the Zeeman Hamiltonian")
         .def("calculate_boltzmann", &ic1ion::calculate_boltzmann, "")
         .def("calculate_moments", &ic1ion::calculate_moments, "")
+        .def("heatcapacity", &ic1ion::heatcapacity, "the heat capacity of the crystal field Hamiltonian in J/mol/K")
         .def("magnetisation", [](ic1ion &self, std::vector<double> H, std::vector<double> Hdir, double T, std::string unit) { return self.magnetisation(H, Hdir, T,
              set_enum(unit, mag_unit_names, "Invalid magnetic unit, must be one of: 'bohr', 'cgs', or 'SI'")); })
         .def("susceptibility", [](ic1ion &self, std::vector<double> T, std::vector<double> Hdir, std::string unit) { return self.susceptibility(T, Hdir,

--- a/src/libmcphase/pyic1ion.cpp
+++ b/src/libmcphase/pyic1ion.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "ic1ion.hpp"
+#include <unordered_map>
 #include <pybind11/pybind11.h>
 #include <pybind11/eigen.h>
 #include <pybind11/stl.h>
@@ -14,9 +15,6 @@
 
 namespace py = pybind11;
 using namespace libMcPhase;
-
-static const std::unordered_map<std::string, physprop::MagUnits> mag_unit_names = {
-    {"bohr", physprop::MagUnits::bohr}, {"cgs", physprop::MagUnits::cgs}, {"SI", physprop::MagUnits::SI} };
 
 static const std::unordered_map<std::string, ic1ion::CoulombType> coulomb_names = {
     {"Slater", ic1ion::CoulombType::Slater}, {"CondonShortley", ic1ion::CoulombType::CondonShortley}, {"Racah", ic1ion::CoulombType::Racah} };
@@ -54,11 +52,11 @@ void wrap_ic1ion(py::module &m) {
         .def("get_ci", &ic1ion::get_ci)
         .def("hamiltonian", &ic1ion::hamiltonian, "the crystal field Hamiltonian")
         .def("eigensystem", &ic1ion::eigensystem, "the eigenvectors and eigenvalues of the crystal field Hamiltonian")
+        .def_property("GJ", [](ic1ion const &self) { return self.get_GJ(); }, [](ic1ion &self, double v) { self.set_GJ(v); })
         .def_property("zeta", [](ic1ion const &self) { return self.get_spinorbit(); }, [](ic1ion &self, double v) { self.set_spinorbit(v, ic1ion::SpinOrbType::Zeta); })
         .def_property("slater", [](ic1ion const &self) { return self.get_coulomb(); }, [](ic1ion &self, std::vector<double> v) { self.set_coulomb(v, ic1ion::CoulombType::Slater); })
         .def("zeeman_hamiltonian", &ic1ion::zeeman_hamiltonian, "the Zeeman Hamiltonian")
         .def("calculate_boltzmann", &ic1ion::calculate_boltzmann, "")
-        .def("calculate_moments", &ic1ion::calculate_moments, "")
         .def("heatcapacity", &ic1ion::heatcapacity, "the heat capacity of the crystal field Hamiltonian in J/mol/K")
         .def("magnetisation", [](ic1ion &self, std::vector<double> H, std::vector<double> Hdir, double T, std::string unit) { return self.magnetisation(H, Hdir, T,
              set_enum(unit, mag_unit_names, "Invalid magnetic unit, must be one of: 'bohr', 'cgs', or 'SI'")); })

--- a/src/libmcphase/pyic1ion.cpp
+++ b/src/libmcphase/pyic1ion.cpp
@@ -6,7 +6,6 @@
  * This program is licensed under the GNU General Purpose License, version 3. Please see the LICENSE file
  */
 
-#include "cfpars.hpp"
 #include "ic1ion.hpp"
 #include <pybind11/pybind11.h>
 #include <pybind11/eigen.h>
@@ -25,11 +24,10 @@ static const std::unordered_map<std::string, ic1ion::CoulombType> coulomb_names 
 static const std::unordered_map<std::string, ic1ion::SpinOrbType> spinorb_names = {
     {"Zeta", ic1ion::SpinOrbType::Zeta}, {"Lambda", ic1ion::SpinOrbType::Lambda} };
 
-void cf_parse(cfpars *cls, py::args args, py::kwargs kwargs);
-
 ic1ion *ic1ion_init(py::args args, py::kwargs kwargs) {
     ic1ion *cls = new ic1ion;
-    cf_parse(static_cast<cfpars*>(cls), args, kwargs);
+    bool is_ic1ion = true;
+    cf_parse(static_cast<cfpars*>(cls), args, kwargs, is_ic1ion);
     if (kwargs.contains("zeta")) {
         cls->set_spinorbit(kwargs["zeta"].cast<double>(), ic1ion::SpinOrbType::Zeta);
     }

--- a/src/singleion/cf1ion.cpp
+++ b/src/singleion/cf1ion.cpp
@@ -176,4 +176,120 @@ std::tuple<RowMatrixXcd, VectorXd> cf1ion::eigensystem() {
     return std::tuple<RowMatrixXcd, VectorXd>(m_eigenvectors, m_eigenvalues);
 }
 
+/*
+// --------------------------------------------------------------------------------------------------------------- //
+// Calculates bulk properties (magnetisation, susceptibility)
+// --------------------------------------------------------------------------------------------------------------- //
+std::vector<double> cf1ion::calculate_boltzmann(VectorXd en, double T)
+{
+    std::vector<double> boltzmann, en_meV;
+    // Need kBT in external energy units. K_B is in meV/K
+    double kBT = K_B * T * m_econv;
+    double Emin = std::numeric_limits<double>::max();
+    for (size_t i=0; i < (size_t)en.size(); i++) {
+        Emin = (en(i) < Emin) ? en(i) : Emin;
+    }
+    for (size_t i=0; i < (size_t)en.size(); i++) {
+        const double expi = exp(-(en(i) - Emin) / kBT);
+        boltzmann.push_back((fabs(expi) > DELTA_EPS) ? expi : 0.);
+    }
+    return boltzmann;
+}
+
+std::vector<double> cf1ion::magnetisation(std::vector<double> Hvec, std::vector<double> Hdir, double T, MagUnits unit_type)
+{
+    // Normalise the field direction vector
+    double Hnorm = sqrt(Hdir[0] * Hdir[0] + Hdir[1] * Hdir[1] + Hdir[2] * Hdir[2]);
+    if (fabs(Hnorm) < 1.e-6) {
+        throw std::runtime_error("cf1ion::magnetisation(): Direction vector cannot be zero");
+    }
+    std::vector<double> nHdir;
+    std::transform(Hdir.begin(), Hdir.end(), std::back_inserter(nHdir), [Hnorm](double Hd){ return Hd / Hnorm; });
+    // Calculates Magnetisation M(H) at specified T
+    if (!m_ham_calc)
+        calculate_hamiltonian();
+    std::vector<double> M;
+    M.reserve(Hvec.size());
+    // Loops through all the input field magnitudes and calculates the magnetisation
+    for (auto H: Hvec) {
+        if (unit_type == MagUnits::cgs) {
+            H /= 1e4;   // For cgs, input field is in Gauss, need to convert to Tesla for Zeeman calculation
+        }
+        RowMatrixXcd ham = m_hamiltonian - zeeman_hamiltonian(H, Hdir);
+        SelfAdjointEigenSolver<RowMatrixXcd> es(ham);
+        // calculate_moments returns a vector of 3 moments *squared* vectors, in the x, y, z directions
+        std::vector< std::vector<double> > moments_vec = calculate_moments(es.eigenvectors());
+        std::vector<double> boltzmann = calculate_boltzmann(es.eigenvalues(), T);
+        std::vector<double> Mdir;
+        for (auto moments: moments_vec) {
+            double Mexp = 0., Z = 0.;
+            //std::inner_product(moments.begin(), moments.end(), boltzmann.begin(), Mexp);
+            //std::accumulate(boltzmann.begin(), boltzmann.end(), Z);
+            for (int ii=0; ii<ham.cols(); ii++) {
+                Mexp += moments[ii] * boltzmann[ii];
+                Z += boltzmann[ii];
+            }
+            Mdir.push_back(Mexp / Z);
+        }
+        M.push_back(sqrt(Mdir[0] * Mdir[0] + Mdir[1] * Mdir[1] + Mdir[2] * Mdir[2]) * MAGCONV[(int)unit_type]);
+    }
+    return M;
+}
+
+std::vector<double> cf1ion::susceptibility(std::vector<double> Tvec, std::vector<double> Hdir, MagUnits unit_type)
+{
+    // Normalise the field direction vector
+    double Hnorm = sqrt(Hdir[0] * Hdir[0] + Hdir[1] * Hdir[1] + Hdir[2] * Hdir[2]);
+    if (fabs(Hnorm) < 1.e-6) {
+        throw std::runtime_error("cf1ion::magnetisation(): Direction vector cannot be zero");
+    }
+    std::vector<double> nHdir;
+    std::transform(Hdir.begin(), Hdir.end(), std::back_inserter(nHdir), [Hnorm](double Hd){ return Hd / Hnorm; });
+    // Calculates the susceptibility chi(T)
+    if (!m_ev_calc)
+        calculate_eigensystem();
+    std::vector<double> chi;
+    chi.reserve(Tvec.size());
+    // Calculates the moments matrices in the x, y, z directions, and get the resultant
+    std::vector<RowMatrixXcd> moments_mat_vec = calculate_moments_matrix(m_eigenvectors);
+    RowMatrixXcd moments_mat = moments_mat_vec[0] * nHdir[0]
+                               + moments_mat_vec[1] * nHdir[1]
+                               + moments_mat_vec[2] * nHdir[2];
+    // Now calculate the first and second order terms in the Van Vleck equation
+    size_t nlev = m_eigenvectors.cols();
+    std::vector<double> mu(nlev, 0.);
+    std::vector<double> mu2(nlev, 0.);
+    for (size_t ii=0; ii<nlev; ii++) {
+        for (size_t jj=0; jj<nlev; jj++) {
+            const double delta = m_eigenvalues[ii] - m_eigenvalues[jj];
+            const double matel = (moments_mat(ii, jj) * std::conj(moments_mat(ii, jj))).real();
+            if (fabs(delta) < DELTA_EPS) {
+                mu[ii] += matel;           // First order term
+            } else {
+                mu2[ii] += matel / delta;  // Second order term
+            }
+        }
+    }
+
+    // Loops through all the input temperatures and calculates the susceptibility using:
+    //                                 2                     2
+    //           N_A --- [ <V_n|mu|V_n>      --- <V_n|mu|V_m>  ]
+    // chi(T) =  --- >   [ ------------  - 2 >   ------------  ] exp(-E/k_BT)
+    //            Z  --- [    k_B T          ---   En - Em     ]
+    //                n                     m!=n
+
+    for (auto T: Tvec) {
+        std::vector<double> boltzmann = calculate_boltzmann(m_eigenvalues, T);
+        const double beta = 1. / (K_B * T);
+        double U = 0., Z = 0.;
+        for (size_t ii=0; ii<nlev; ii++) {
+            U += ((mu[ii] * beta) - (2 * mu2[ii])) * boltzmann[ii];
+            Z += boltzmann[ii];
+        }
+        chi.push_back(SUSCCONV[(int)unit_type] * U / Z);
+    }
+    return chi;
+}
+*/
+
 } // namespace libMcPhase

--- a/src/singleion/cf1ion.cpp
+++ b/src/singleion/cf1ion.cpp
@@ -202,13 +202,13 @@ void cf1ion::calc_mag_ops() {
     double rm1 = sqrt( m_racah.f(m_J2 + 2) / m_racah.f(m_J2 - 1) ) / 2.;
     double rm1_sq2 = rm1 / sqrt(2.);
     for (size_t i=0; i<dimj; i++) {
-        int mj = 2*i - m_J2;
+        int mj = 2*(int)i - m_J2;
         double phase = pow(-1., (m_J2-mj)/2.);
         // The diagonal elements (the Jz operator)
         m_magops[2](i,i) += phase * m_racah.threej(m_J2, 2, m_J2, -mj, 0, mj) * rm1;
         // The off-diagonal elements
         if (i < dimj-1) {
-            int mjp = 2*(i+1) - m_J2;
+            int mjp = 2*((int)i+1) - m_J2;
             double Op = phase * m_racah.threej(m_J2, 2, m_J2, -mj, 2, mjp) * rm1_sq2;
             double Om = phase * m_racah.threej(m_J2, 2, m_J2, -mj, -2, mjp) * rm1_sq2;
             m_magops[0](i+1,i) += Om - Op;                            // Jx

--- a/src/singleion/cf1ion.cpp
+++ b/src/singleion/cf1ion.cpp
@@ -46,12 +46,14 @@ void cf1ion::set_name(const std::string &ionname) {
     cfpars::set_name(ionname);
     m_ham_calc = false;
     m_ev_calc = false;
+    m_magops_calc = false;
 }
 
 void cf1ion::set_J(const double J) {
     cfpars::set_J(J);
     m_ham_calc = false;
     m_ev_calc = false;
+    m_magops_calc = false;
 }
 
 // --------------------------------------------------------------------------------------------------------------- //
@@ -190,19 +192,66 @@ std::tuple<RowMatrixXcd, VectorXd> cf1ion::eigensystem() {
     return std::tuple<RowMatrixXcd, VectorXd>(m_eigenvectors, m_eigenvalues);
 }
 
+void cf1ion::calc_mag_ops() {
+    // Calculates the magnetic operators Jx, Jy, Jz
+    if (m_magops_calc)
+        return;
+    int dimj = m_J2 + 1;
+    m_magops = std::vector<RowMatrixXcd>(3, RowMatrixXcd::Zero(dimj, dimj));
+    // RM1 = (1/2) * sqrt( factorial(2*J+1+1) / factorial(2*J-1) );
+    double rm1 = sqrt( m_racah.f(m_J2 + 2) / m_racah.f(m_J2 - 1) ) / 2.;
+    double rm1_sq2 = rm1 / sqrt(2.);
+    for (size_t i=0; i<dimj; i++) {
+        int mj = 2*i - m_J2;
+        double phase = pow(-1., (m_J2-mj)/2.);
+        // The diagonal elements (the Jz operator)
+        m_magops[2](i,i) += phase * m_racah.threej(m_J2, 2, m_J2, -mj, 0, mj) * rm1;
+        // The off-diagonal elements
+        if (i < dimj-1) {
+            int mjp = 2*(i+1) - m_J2;
+            double Op = phase * m_racah.threej(m_J2, 2, m_J2, -mj, 2, mjp) * rm1_sq2;
+            double Om = phase * m_racah.threej(m_J2, 2, m_J2, -mj, -2, mjp) * rm1_sq2;
+            m_magops[0](i+1,i) += Om - Op;                            // Jx
+            m_magops[1](i+1,i) += std::complex<double>(0., Om + Op);  // Jy
+        }
+    }
+    // Fill the upper triangle
+    for (int i=0; i<dimj-1; i++) {
+        m_magops[0](i,i+1) = m_magops[0](i+1,i);
+        m_magops[1](i,i+1) = std::conj(m_magops[1](i+1,i));
+    }
+    m_magops_calc = true;
+}
+
 RowMatrixXcd cf1ion::zeeman_hamiltonian(double H, std::vector<double> Hdir) {
+    if (m_GJ < 0) {
+        throw std::runtime_error("Lande g-factor not defined. Either set the ion name or set GJ.");
+    }
+    if (Hdir.size() != 3) {
+        throw std::runtime_error("cf1ion::zeeman_hamiltonian(): Hdir must be a 3-vector");
+    }
+    // Normalise the field direction vector
+    double Hnorm = sqrt(Hdir[0] * Hdir[0] + Hdir[1] * Hdir[1] + Hdir[2] * Hdir[2]);
+    if (fabs(Hnorm) < 1.e-6) {
+        throw std::runtime_error("cf1ion::zeeman_hamiltonian(): Direction vector cannot be zero");
+    }
+    std::vector<double> nHdir;
+    std::transform(Hdir.begin(), Hdir.end(), std::back_inserter(nHdir), [Hnorm](double Hd){ return Hd / Hnorm; });
+    // Calculates the Jx, Jy, Jz operators if not done already.
+    calc_mag_ops();
     RowMatrixXcd zeeman = RowMatrixXcd::Zero(m_J2+1, m_J2+1);
-    return zeeman;
+    zeeman = (m_magops[0] * nHdir[0]) + (m_magops[1] * nHdir[1]) + (m_magops[2] * nHdir[2]);
+    double H_in_energy = m_GJ * H * MU_B * m_econv; // want H in user requested external energy units
+    return (zeeman * H_in_energy);
 }
 
 std::vector<RowMatrixXcd> cf1ion::calculate_moments_matrix(RowMatrixXcd ev) {
+    calc_mag_ops();
     std::vector<RowMatrixXcd> moments;
     for (size_t ii=0; ii<3; ii++) {
-        RowMatrixXcd Jmat = RowMatrixXcd::Zero(ev.rows(), ev.cols());
-        moments.push_back((ev.adjoint()) * (Jmat * ev));
+        moments.push_back((ev.adjoint()) * (m_magops[ii] * ev) * m_GJ);
     }
     return moments;
 }
-
 
 } // namespace libMcPhase

--- a/src/singleion/cfpars.cpp
+++ b/src/singleion/cfpars.cpp
@@ -173,7 +173,7 @@ void cfpars::set(int l, int m, double val) {
     m_Bi[id] = val / m_convfact[id] / m_econv;
 }
 
-const double cfpars::get(int l, int m) const {
+double cfpars::get(int l, int m) const {
     switch(l) {
         case 2: return m_Bo[2 + m];
         case 4: return m_Bo[9 + m];
@@ -244,6 +244,7 @@ void cfpars::set_name(const std::string &ionname) {
     }
 	m_stevfact = {alpha, beta, gamma};
 	m_convertible = true;
+    m_GJ = GJ[m_n];
     // Now reset the conversion table (from internal to external parameters)
     this->set_type(m_type);
 }

--- a/src/singleion/cfpars.cpp
+++ b/src/singleion/cfpars.cpp
@@ -133,9 +133,6 @@ const Map3 &RKTABLE() {
     return rk_table;
 }
 
-// Conversion factors for different energy units[from][to], order: [meV, cm, K].
-static const std::array<double, 3> ENERGYCONV = { {1., 8.065544005, 11.6045221} };
-
 // --------------------------------------------------------------------------------------------------------------- //
 // General methods for cfpars class
 // --------------------------------------------------------------------------------------------------------------- //

--- a/src/singleion/cfpars.cpp
+++ b/src/singleion/cfpars.cpp
@@ -10,9 +10,6 @@
 
 namespace libMcPhase {
 
-static const double K_B = 0.08617343183;       // meV/K - Boltzmann constant
-static const double MU_B = 0.0578838263;       // meV/T - Bohr magneton
-
 // --------------------------------------------------------------------------------------------------------------- //
 // Reference tables (values taken from program cfield, by Peter Fabi, FZ Juelich, file theta.c)
 // --------------------------------------------------------------------------------------------------------------- //

--- a/src/singleion/ic1ion.cpp
+++ b/src/singleion/ic1ion.cpp
@@ -25,9 +25,6 @@ static const double F625 = 0.016104;       // Ratios of F_6/F_2 slater integrals
 // Conversion factors for different energy units[from][to], order: [meV, cm, K].
 static const std::array<double, 3> ICENERGYCONV = {0.1239841973, 1., 1.4387773587};
 
-// EPSILON to determine if energy levels are degenerate or not
-static const double DELTA_EPS = 1e-6;
-
 // Helper vectors for indexing into CF parameters array
 static const std::array<std::array<int, 4>, 12> idq = { {{2,2,0,4}, {2,1,1,3}, {4,4,5,13}, {4,3,6,12}, {4,2,7,11}, {4,1,8,10},
                                                         {6,6,14,26}, {6,5,15,25}, {6,4,16,24}, {6,3,17,23}, {6,2,18,22}, {6,1,19,21}} };

--- a/src/singleion/ic1ion.cpp
+++ b/src/singleion/ic1ion.cpp
@@ -25,22 +25,6 @@ static const double F625 = 0.016104;       // Ratios of F_6/F_2 slater integrals
 // Conversion factors for different energy units[from][to], order: [meV, cm, K].
 static const std::array<double, 3> ICENERGYCONV = {0.1239841973, 1., 1.4387773587};
 
-// Conversion factors for different magnetic units for magnetisation. Order: [bohr, cgs, SI].
-// NAMUB is N_A * MU_B in J/T/mol == Am^2/mol is the SI unit. 
-// The cgs unit is N_A * MU_B in erg/G/mol == emu/mol is different only by a factor of 1000 larger
-static const std::array<double, 3> MAGCONV = {1., NAMUB*1000, NAMUB};
-
-// Note these constants are strange because the default energy unit in this module is cm-1
-static const double NAMUBSQ_ERG = 0.26074098;     // N_A * muB[erg/G] * muB[cm/T] * [Tesla_to_Gauss=1e-4]
-static const double NAMUBSQ_JOULE = 3.276568e-06; // N_A * muB[J/T] * muB[cm/T] * mu0
-// Factor of mu0 is needed in SI due to different definition of the magnetisation, B and H fields
-
-// Conversion factors for different magnetic units for magnetic susceptibility. Order: [bohr, cgs, SI].
-// The susceptibility prefactor is (in principle) N_A * MU_B^2 but we need to account for various units...
-// The atomic (bohr) susceptibility is in uB/T/ion; cgs is in erg/G^2/mol==cm^3/mol; SI in J/T^2/mol==m^3/mol
-// Note that chi_SI = (4pi*10^-6)chi_cgs [*not* 4pi*10-7!]
-static const std::array<double, 3> SUSCCONV = {MU_B, NAMUBSQ_ERG, NAMUBSQ_JOULE};
-
 // EPSILON to determine if energy levels are degenerate or not
 static const double DELTA_EPS = 1e-6;
 
@@ -642,9 +626,9 @@ RowMatrixXcd ic1ion::hamiltonian() {
 // --------------------------------------------------------------------------------------------------------------- //
 std::vector<double> ic1ion::calculate_boltzmann(VectorXd en, double T)
 {
-    std::vector<double> boltzmann, en_meV;
-    // Need kBT in external energy units. K_B is in meV/K
-    double kBT = K_B * T * m_econv;
+    std::vector<double> boltzmann;
+    // Need kBT in external energy units. K_B is in cm-1/K
+    double kBT = K_Bc * T * m_econv;
     double Emin = std::numeric_limits<double>::max();
     for (size_t i=0; i < (size_t)en.size(); i++) {
         Emin = (en(i) < Emin) ? en(i) : Emin;

--- a/src/singleion/ic1ion.cpp
+++ b/src/singleion/ic1ion.cpp
@@ -71,6 +71,7 @@ void ic1ion::set_unit(cfpars::Units const newunit) {
         if (ii < 3) 
             m_alpha[ii] = m_alpha_i[ii] * m_econv;
     }
+    physprop::m_meVconv = ENERGYCONV[(int)m_unit];
 }
 
 void ic1ion::set_type(const cfpars::Type newtype) {
@@ -616,120 +617,6 @@ RowMatrixXcd ic1ion::hamiltonian() {
     if (!m_ham_calc)
         calculate_hamiltonian();
     return m_hamiltonian;
-}
-
-// --------------------------------------------------------------------------------------------------------------- //
-// Calculates bulk properties (magnetisation, susceptibility)
-// --------------------------------------------------------------------------------------------------------------- //
-std::vector<double> ic1ion::calculate_boltzmann(VectorXd en, double T)
-{
-    std::vector<double> boltzmann;
-    // Need kBT in external energy units. K_B is in cm-1/K
-    double kBT = K_Bc * T * m_econv;
-    double Emin = std::numeric_limits<double>::max();
-    for (size_t i=0; i < (size_t)en.size(); i++) {
-        Emin = (en(i) < Emin) ? en(i) : Emin;
-    }
-    for (size_t i=0; i < (size_t)en.size(); i++) {
-        const double expi = exp(-(en(i) - Emin) / kBT);
-        boltzmann.push_back((fabs(expi) > DELTA_EPS) ? expi : 0.);
-    }
-    return boltzmann;
-}
-
-std::vector<double> ic1ion::magnetisation(std::vector<double> Hvec, std::vector<double> Hdir, double T, MagUnits unit_type)
-{
-    // Normalise the field direction vector
-    double Hnorm = sqrt(Hdir[0] * Hdir[0] + Hdir[1] * Hdir[1] + Hdir[2] * Hdir[2]);
-    if (fabs(Hnorm) < 1.e-6) {
-        throw std::runtime_error("ic1ion::magnetisation(): Direction vector cannot be zero");
-    }
-    std::vector<double> nHdir;
-    std::transform(Hdir.begin(), Hdir.end(), std::back_inserter(nHdir), [Hnorm](double Hd){ return Hd / Hnorm; });
-    // Calculates Magnetisation M(H) at specified T
-    if (!m_ham_calc)
-        calculate_hamiltonian();
-    std::vector<double> M;
-    M.reserve(Hvec.size());
-    // Loops through all the input field magnitudes and calculates the magnetisation
-    for (auto H: Hvec) {
-        if (unit_type == MagUnits::cgs) {
-            H /= 1e4;   // For cgs, input field is in Gauss, need to convert to Tesla for Zeeman calculation
-        }
-        RowMatrixXcd ham = m_hamiltonian - zeeman_hamiltonian(H, Hdir);
-        SelfAdjointEigenSolver<RowMatrixXcd> es(ham);
-        // calculate_moments returns a vector of 3 moments *squared* vectors, in the x, y, z directions
-        std::vector< std::vector<double> > moments_vec = calculate_moments(es.eigenvectors());
-        std::vector<double> boltzmann = calculate_boltzmann(es.eigenvalues(), T);
-        std::vector<double> Mdir;
-        for (auto moments: moments_vec) {
-            double Mexp = 0., Z = 0.;
-            //std::inner_product(moments.begin(), moments.end(), boltzmann.begin(), Mexp);
-            //std::accumulate(boltzmann.begin(), boltzmann.end(), Z);
-            for (int ii=0; ii<ham.cols(); ii++) {
-                Mexp += moments[ii] * boltzmann[ii];
-                Z += boltzmann[ii];
-            }
-            Mdir.push_back(Mexp / Z);
-        }
-        M.push_back(sqrt(Mdir[0] * Mdir[0] + Mdir[1] * Mdir[1] + Mdir[2] * Mdir[2]) * MAGCONV[(int)unit_type]);
-    }
-    return M;
-}
-
-std::vector<double> ic1ion::susceptibility(std::vector<double> Tvec, std::vector<double> Hdir, MagUnits unit_type)
-{
-    // Normalise the field direction vector
-    double Hnorm = sqrt(Hdir[0] * Hdir[0] + Hdir[1] * Hdir[1] + Hdir[2] * Hdir[2]);
-    if (fabs(Hnorm) < 1.e-6) {
-        throw std::runtime_error("ic1ion::magnetisation(): Direction vector cannot be zero");
-    }
-    std::vector<double> nHdir;
-    std::transform(Hdir.begin(), Hdir.end(), std::back_inserter(nHdir), [Hnorm](double Hd){ return Hd / Hnorm; });
-    // Calculates the susceptibility chi(T)
-    if (!m_ev_calc)
-        calculate_eigensystem();
-    std::vector<double> chi;
-    chi.reserve(Tvec.size());
-    // Calculates the moments matrices in the x, y, z directions, and get the resultant
-    std::vector<RowMatrixXcd> moments_mat_vec = calculate_moments_matrix(m_eigenvectors);
-    RowMatrixXcd moments_mat = moments_mat_vec[0] * nHdir[0]
-                               + moments_mat_vec[1] * nHdir[1]
-                               + moments_mat_vec[2] * nHdir[2];
-    // Now calculate the first and second order terms in the Van Vleck equation
-    size_t nlev = m_eigenvectors.cols();
-    std::vector<double> mu(nlev, 0.);
-    std::vector<double> mu2(nlev, 0.);
-    for (size_t ii=0; ii<nlev; ii++) {
-        for (size_t jj=0; jj<nlev; jj++) {
-            const double delta = m_eigenvalues[ii] - m_eigenvalues[jj];
-            const double matel = (moments_mat(ii, jj) * std::conj(moments_mat(ii, jj))).real();
-            if (fabs(delta) < DELTA_EPS) {
-                mu[ii] += matel;           // First order term
-            } else {
-                mu2[ii] += matel / delta;  // Second order term
-            }
-        }
-    }
-
-    // Loops through all the input temperatures and calculates the susceptibility using:
-    //                                 2                     2
-    //           N_A --- [ <V_n|mu|V_n>      --- <V_n|mu|V_m>  ]
-    // chi(T) =  --- >   [ ------------  - 2 >   ------------  ] exp(-E/k_BT)
-    //            Z  --- [    k_B T          ---   En - Em     ]
-    //                n                     m!=n
-
-    for (auto T: Tvec) {
-        std::vector<double> boltzmann = calculate_boltzmann(m_eigenvalues, T);
-        const double beta = 1. / (K_B * T);
-        double U = 0., Z = 0.;
-        for (size_t ii=0; ii<nlev; ii++) {
-            U += ((mu[ii] * beta) - (2 * mu2[ii])) * boltzmann[ii];
-            Z += boltzmann[ii];
-        }
-        chi.push_back(SUSCCONV[(int)unit_type] * U / Z);
-    }
-    return chi;
 }
 
 /*

--- a/src/singleion/ic_cfp.cpp
+++ b/src/singleion/ic_cfp.cpp
@@ -37,14 +37,14 @@ double racah_ulf(qG2 U, orbital L, qG2 Up, orbital Lp)
    double ulf=0;
    int id=-1;
 
-   if(Up.isequal("00") && Lp==S && U.isequal("10") && L==F) { ulf = 1.; }             // Column 1 of Table IV, Racah IVa.
+   if(Up.isequal(00) && Lp==S && U.isequal(10) && L==F) { ulf = 1.; }             // Column 1 of Table IV, Racah IVa.
    else if(Up.u1==0 && Up.u2==0 && Lp==S && U.u1==1 && U.u2==0 && L==F) { ulf = 1.; } //   ditto - to overcome isequal bug
-   else if(Up.isequal("10") && Lp==3)                                                 // Column 2 of Table IV, Racah IVa. 
+   else if(Up.isequal(10) && Lp==3)                                                 // Column 2 of Table IV, Racah IVa. 
    {
-      if((U.isequal("10")&&L==3) || (U.isequal("11")&&(L==1||L==5)) || (U.isequal("20")&&(L==2||L==4||L==6))) { ulf = 1.; }
-      else if(U.isequal("00") && L==0) { ulf = -1.; }
+      if((U.isequal(10)&&L==3) || (U.isequal(11)&&(L==1||L==5)) || (U.isequal(20)&&(L==2||L==4||L==6))) { ulf = 1.; }
+      else if(U.isequal(00) && L==0) { ulf = -1.; }
    }
-   else if(Up.isequal("11") || Up.isequal("20") || Up.isequal("21"))
+   else if(Up.isequal(11) || Up.isequal(20) || Up.isequal(21))
    {
       // U' | (11)  |       |       (20)       |          |               (21)               |                  L  U
       // L' P       H       D        G         I       [  D       F      G      H     K      L
@@ -77,21 +77,21 @@ double racah_ulf(qG2 U, orbital L, qG2 Up, orbital Lp)
             0,      0,      0,       0,        0,         0,      0,     0,     0,   -5,    11,};//]./ 16];   % N
       // ^------------ Racah IV, table IVa --------------^     ^--------- Racah IV, table IVb ----------^
 #define SW(u,l,i) if(U.isequal(u)&&L==l) id=i
-      SW("00",S,0); SW("10",F,1); SW("11",P,2); SW("11",H,3); SW("20",D,4); SW("20",G,5); SW("20",I,6);
+      SW(00,S,0); SW(10,F,1); SW(11,P,2); SW(11,H,3); SW(20,D,4); SW(20,G,5); SW(20,I,6);
 #define SL(l,i) else if(L==l) id=i
-      if(U.isequal("21")) { if(L==2) id=7; SL(3,8); SL(4,9); SL(5,10); SL(7,11); SL(8,12); }
-      if(U.isequal("30")) { if(L==1) id=13; SL(3,14); SL(4,15); SL(5,16); SL(6,17); SL(7,18); SL(9,19); }
-      if(U.isequal("22")) { if(L==0) id=20; SL(2,21); SL(4,22); SL(5,23); SL(6,24); SL(8,25); SL(10,26); }
-      if(id<0) { if(Up.isequal("21")) { id = -1; } else { return ulf; } }
+      if(U.isequal(21)) { if(L==2) id=7; SL(3,8); SL(4,9); SL(5,10); SL(7,11); SL(8,12); }
+      if(U.isequal(30)) { if(L==1) id=13; SL(3,14); SL(4,15); SL(5,16); SL(6,17); SL(7,18); SL(9,19); }
+      if(U.isequal(22)) { if(L==0) id=20; SL(2,21); SL(4,22); SL(5,23); SL(6,24); SL(8,25); SL(10,26); }
+      if(id<0) { if(Up.isequal(21)) { id = -1; } else { return ulf; } }
 
-      if(Up.isequal("11")) { if(Lp==P) { ulf = t[id*11]; } else if(Lp==H) { ulf = t[id*11+1]; } }
-      else if(Up.isequal("20"))
+      if(Up.isequal(11)) { if(Lp==P) { ulf = t[id*11]; } else if(Lp==H) { ulf = t[id*11+1]; } }
+      else if(Up.isequal(20))
       {
          if(Lp==D) { ulf = t[id*11+2]; }
          else if(Lp==G) { ulf = t[id*11+3]; }
          else if(Lp==I) { ulf = t[id*11+4]; }
       }
-      else if(Up.isequal("21"))
+      else if(Up.isequal(21))
       {
          if(id!=-1)
 	 {
@@ -105,7 +105,7 @@ double racah_ulf(qG2 U, orbital L, qG2 Up, orbital Lp)
             else if(Lp==8) { 
 	    ulf = t[id*11+10]/den[id]; }
 	 }
-  	 else if(U.isequal("31"))
+  	 else if(U.isequal(31))
 	 {
             // Table IIb from Wybourne, J. Chem. Phys. 36 (1961) 2295, modified by numbers from ACRY program of Allison
             // U'=(21) D        F        G        H        K        L                         U=(31)
@@ -148,7 +148,7 @@ double racah_ulf(qG2 U, orbital L, qG2 Up, orbital Lp)
 	 }
       }
    }
-   else if(Up.isequal("30"))
+   else if(Up.isequal(30))
    {
       //  .--------------------- Table IVc, from Racah IV --------------------.
       // U'                               (30)                                                          L  U
@@ -216,12 +216,12 @@ double racah_ulf(qG2 U, orbital L, qG2 Up, orbital Lp)
                 0,         0,         0,         0,         0,         0,         1}; //];            % Q
       // Reminder: #define SW(u,l,i) if(U.isequal(u)&&L==l) id=i
       //           #define CD(c,d) case c: id = d; break
-      SW("20",D,0); SW("20",G,1); SW("20",I,2);
-      if(U.isequal("21")) { switch (L) { CD(D,3);  CD(F,4);  CD(G,5);  CD(H,6);   CD(K,7);  CD(8,8); default: return ulf; } }
-      if(U.isequal("30")) { switch (L) { CD(P,9);  CD(F,10); CD(G,11); CD(H,12);  CD(I,13); CD(K,14); CD(M,15); default: return ulf; } }
-      if(U.isequal("31")) { switch (L) { CD(P,16); CD(D,17); CD(F,18); CD(Fp,19); CD(G,20); CD(H,21); CD(Hp,22); CD(I,23); 
+      SW(20,D,0); SW(20,G,1); SW(20,I,2);
+      if(U.isequal(21)) { switch (L) { CD(D,3);  CD(F,4);  CD(G,5);  CD(H,6);   CD(K,7);  CD(8,8); default: return ulf; } }
+      if(U.isequal(30)) { switch (L) { CD(P,9);  CD(F,10); CD(G,11); CD(H,12);  CD(I,13); CD(K,14); CD(M,15); default: return ulf; } }
+      if(U.isequal(31)) { switch (L) { CD(P,16); CD(D,17); CD(F,18); CD(Fp,19); CD(G,20); CD(H,21); CD(Hp,22); CD(I,23); 
                                          CD(Ip,24); CD(K,25); CD(Kp,26); CD(8,27); CD(M,28); CD(N,29); CD(O,30); default: return ulf; } }
-      if(U.isequal("40")) { switch (L) { CD(S,31); CD(D,32); CD(F,33); CD(G,34); CD(Gp,35); CD(H,36); CD(I,37); CD(Ip,38); 
+      if(U.isequal(40)) { switch (L) { CD(S,31); CD(D,32); CD(F,33); CD(G,34); CD(Gp,35); CD(H,36); CD(I,37); CD(Ip,38); 
                                          CD(K,39); CD(8,40); CD(-8,41); CD(M,42); CD(N,43); CD(Q,44); default: return ulf; } }
       double den[] = {490.,5929.,22022.,2695.,1694.,630630.,55055.,165165.,17017.,16.,1232.,55440.,11440.,32032.,
                       510510.,3808.,16.,3080.,2541.,3696.,240240.,68640.,1057056.,5285280.,680680.,1,1,272272.,
@@ -234,8 +234,8 @@ double racah_ulf(qG2 U, orbital L, qG2 Up, orbital Lp)
       else if(Lp==I) { ulf = t[id*7+4]/den[id]; }
       else if(Lp==K) { ulf = t[id*7+5]/den[id]; }
       else if(Lp==M) { ulf = t[id*7+6]/den[id]; }
-   }  // if(Up.isequal("30")
-   else if(Up.isequal("22"))
+   }  // if(Up.isequal(30)
+   else if(Up.isequal(22))
    {
       // T6 is not complete! It has been partially reassembled from the tabulated cfp listed in 
       //   C.W. Neilson and G.F. Koster, 1963.
@@ -263,9 +263,9 @@ double racah_ulf(qG2 U, orbital L, qG2 Up, orbital Lp)
                  0,    -4095,      121296,      -6864,      46410,      -206720,           0, //] ./ 385385; % H
                  0,        0,        1008,        572,       4459,         8976,        8580, //] ./ 23595;  % K
                  0,        0,           0,       1020,        315,        -1360,        6468};//] ./ 9163];  % L
-      if(U.isequal("31")) { switch (L) { CD(P,0); CD(D,1); CD(F,2); CD(Fp,3); CD(G,4); CD(H,5); CD(Hp,6); CD(I,7); 
+      if(U.isequal(31)) { switch (L) { CD(P,0); CD(D,1); CD(F,2); CD(Fp,3); CD(G,4); CD(H,5); CD(Hp,6); CD(I,7); 
                                          CD(Ip,8); CD(K,9); CD(Kp,10); CD(8,11); CD(M,12); CD(N,13); CD(O,14); default: return ulf; } }
-      if(U.isequal("21")) { switch (L) { CD(D,15); CD(F,16); CD(G,17); CD(H,18); CD(K,19); CD(8,20); default: return ulf; } }
+      if(U.isequal(21)) { switch (L) { CD(D,15); CD(F,16); CD(G,17); CD(H,18); CD(K,19); CD(8,20); default: return ulf; } }
       double den[] = {35.,1925.,12705.,2310.,11550.,150150.,330330.,25025.,25025.,1265.,354200.,1,1,95.,19.,1,
                       11858.,6930.,385385.,23595.,9163.};
       if(id<0) { return ulf; }
@@ -277,7 +277,7 @@ double racah_ulf(qG2 U, orbital L, qG2 Up, orbital Lp)
       else if(Lp==8) { ulf = t[id*7+5]/den[id]; }
       else if(Lp==N) { ulf = t[id*7+6]/den[id]; }
    }
-   else if(Up.isequal("31"))
+   else if(Up.isequal(31))
    {  /*
       % Tables from ACRY program of Allison et al. (Comp. Phys. Comm. vol 8, p 246-256, 1974)
       % Expressed in rational form by guesswork and using the reciprocity relations (Judd 1963, p180, eq 7-37)
@@ -297,7 +297,7 @@ double racah_ulf(qG2 U, orbital L, qG2 Up, orbital Lp)
                 0           0           0           0           0           0;          % D  (20)
                 0           0           0           0           0           0;          % G
                 0           0           0           0           0           0;          % I */
-      if(U.isequal("21"))
+      if(U.isequal(21))
       {
          //id = (L==D?0:-1)+(L==F?1:-1)+(L==G?2:-1)+(L==H?3:-1)+(L==K?4:-1)+(L==L?5:-1); if(id<0) { return ulf; }
 	 switch (L) { CD(D,0); CD(F,1); CD(G,2); CD(H,3); CD(K,4); CD(8,5); default: return ulf; } 
@@ -339,7 +339,7 @@ double racah_ulf(qG2 U, orbital L, qG2 Up, orbital Lp)
            %    -125000/147147 -12160/682227 640/4851    95/1071     20/153     -1472/3213;  % L
            %-------------------- Reciprocal of original Wybourne values ---------------------%  */
       }
-      else if(U.isequal("22"))
+      else if(U.isequal(22))
       {
 	 switch (L) { CD(S,0); CD(D,1); CD(G,2); CD(H,3); CD(I,4); CD(8,5); CD(N,6); default: return ulf; }
          if(abs(Lp)<6 || Lp==I)
@@ -369,7 +369,7 @@ double racah_ulf(qG2 U, orbital L, qG2 Up, orbital Lp)
 	    else if(Lp==M) { ulf = t[id*7+4]; } else if(Lp==N)  { ulf = t[id*7+5]; } else if(Lp==O) { ulf = t[id*7+6]; }
 	 }
       }
-      else if(U.isequal("30"))
+      else if(U.isequal(30))
       {
 	 switch (L) { CD(P,0); CD(F,1); CD(G,2); CD(H,3); CD(I,4); CD(K,5); CD(M,6); default: return ulf; }
          if(abs(Lp)<6 || Lp==I)
@@ -399,7 +399,7 @@ double racah_ulf(qG2 U, orbital L, qG2 Up, orbital Lp)
 	    else if(Lp==M) { ulf = t[id*7+4]; } else if(Lp==N)  { ulf = t[id*7+5]; } else if(Lp==O) { ulf = t[id*7+6]; }
          }
       }
-      else if(U.isequal("31"))
+      else if(U.isequal(31))
       {
          switch (L) { CD(P,0); CD(D,1); CD(F,2); CD(Fp,3); CD(G,4); CD(H,5); CD(Hp,6); CD(I,7); 
                       CD(Ip,8); CD(K,9); CD(Kp,10); CD(8,11); CD(M,12); CD(N,13); CD(O,14); default: return ulf; break; }
@@ -446,7 +446,7 @@ double racah_ulf(qG2 U, orbital L, qG2 Up, orbital Lp)
 	    else if(Lp==M) { ulf = t[id*7+4]; } else if(Lp==N)  { ulf = t[id*7+5]; } else if(Lp==O) { ulf = t[id*7+6]; }
          }
       }
-      else if(U.isequal("40"))
+      else if(U.isequal(40))
       {
          switch (L) { CD(S,0); CD(D,1); CD(F,2); CD(G,3); CD(Gp,4); CD(H,5); CD(I,6); CD(Ip,7); CD(K,8); 
 	              CD(8,9); CD(-8,10); CD(M,11); CD(N,12); CD(Q,13); default: return ulf; break; }
@@ -492,10 +492,10 @@ double racah_ulf(qG2 U, orbital L, qG2 Up, orbital Lp)
 	    else if(Lp==M) { ulf = t[id*6+3]; } else if(Lp==N)  { ulf = t[id*6+4]; } else if(Lp==O) { ulf = t[id*6+5]; }
          }
       }
-   } // if(Up.isequal("31"))
-   else if(Up.isequal("40"))
+   } // if(Up.isequal(31))
+   else if(Up.isequal(40))
    {
-      if(U.isequal("30"))
+      if(U.isequal(30))
       {
 	 switch (L) { CD(P,0); CD(F,1); CD(G,2); CD(H,3); CD(I,4); CD(K,5); CD(M,6); default: return ulf; }
          if(abs(Lp)<8)
@@ -531,7 +531,7 @@ double racah_ulf(qG2 U, orbital L, qG2 Up, orbital Lp)
               0,         0,         0,         0,         0,         0,         0,         0,         0,        // I
               0,         0,         0,         0,         0,         0,         0,         0,         0,        // L
               0,         0,         0,         0,         0,         0,         0,         0,         0,        // N */
-      else if(U.isequal("31"))
+      else if(U.isequal(31))
       {
          switch (L) { CD(P,0); CD(D,1); CD(F,2); CD(Fp,3); CD(G,4); CD(H,5); CD(Hp,6); CD(I,7); 
                       CD(Ip,8); CD(K,9); CD(Kp,10); CD(8,11); CD(M,12); CD(N,13); CD(O,14); default: return ulf; break; }
@@ -577,7 +577,7 @@ double racah_ulf(qG2 U, orbital L, qG2 Up, orbital Lp)
             else if(Lp==N)  { ulf = t[id*5+3]; } else if(Lp==Q)  { ulf = t[id*5+4]; }
          }
       }
-      else if(U.isequal("40"))
+      else if(U.isequal(40))
       {
          switch (L) { CD(S,0); CD(D,1); CD(F,2); CD(G,3); CD(Gp,4); CD(H,5); CD(I,6); CD(Ip,7); CD(K,8); 
 	              CD(8,9); CD(-8,10); CD(M,11); CD(N,12); CD(Q,13); default: return ulf; break; }
@@ -621,7 +621,7 @@ double racah_ulf(qG2 U, orbital L, qG2 Up, orbital Lp)
             else if(Lp==N)  { ulf = t[id*5+3]; } else if(Lp==Q)  { ulf = t[id*5+4]; }
          }
       }
-   } // if(Up.isequal("40"))
+   } // if(Up.isequal(40))
    if(ulf==0) { return ulf; }
    else { 
    //std::cout << sqrt(fabs(ulf))*(ulf/fabs(ulf)) << "\t"; 
@@ -668,52 +668,52 @@ t=[0   1    0    0   0    0    0    0    0     0     0     0     0     0    0   
 % Table continues below, reconstructed from tabulated cfp and also from the code of Allison and McNulty CPC 8 (1974) 246
 % And also using the reciprocity relations (Judd, Op. Techniques in At. Spectr., p.181, eq 7-36). */
 
-   if(Wp.isequal("000") && Up.isequal("00") && W.isequal("100") && U.isequal("10")) { wupf = 1.; }
+   if(Wp.isequal(000) && Up.isequal(00) && W.isequal(100) && U.isequal(10)) { wupf = 1.; }
 #define EQ(uw,v) uw.isequal(v)
-   else if((EQ(Wp,"100")&&EQ(Up,"10"))&&((EQ(W,"000")&&EQ(U,"00"))||(EQ(W,"110")&&(EQ(U,"10")||EQ(U,"11")))||
-           (EQ(W,"200")&&EQ(U,"20")))) { wupf=1.; }
-   else if((EQ(Wp,"200")&&EQ(Up,"20"))&&((EQ(W,"100")&&EQ(U,"10"))||(EQ(W,"210")&&(EQ(U,"11")||EQ(U,"20")||EQ(U,"21"))))) 
+   else if((EQ(Wp,100)&&EQ(Up,10))&&((EQ(W,000)&&EQ(U,00))||(EQ(W,110)&&(EQ(U,10)||EQ(U,11)))||
+           (EQ(W,200)&&EQ(U,20)))) { wupf=1.; }
+   else if((EQ(Wp,200)&&EQ(Up,20))&&((EQ(W,100)&&EQ(U,10))||(EQ(W,210)&&(EQ(U,11)||EQ(U,20)||EQ(U,21))))) 
      { wupf = 1.; }
-   else if(Wp.isequal("110"))
+   else if(Wp.isequal(110))
    {
 #define UW(w,u,i) else if(W.isequal(w)&&U.isequal(u)) id=i
-      if(W.isequal("000")&&U.isequal("00")) id=0; UW("100","10",1); UW("110","10",2); UW("110","11",3); UW("200","20",4);
-         UW("111","00",5); UW("111","10",6); UW("111","20",7); UW("210","11",8); UW("210","20",9); UW("210","21",10); 
+      if(W.isequal(000)&&U.isequal(00)) id=0; UW(100,10,1); UW(110,10,2); UW(110,11,3); UW(200,20,4);
+         UW(111,00,5); UW(111,10,6); UW(111,20,7); UW(210,11,8); UW(210,20,9); UW(210,21,10); 
       else { return wupf; }
-      if(Up.isequal("10")) { double t[] = {0,1./3,0,0,0,1.,2./3,2./9,1.,7./9,0}; wupf = t[id]; }
-      else if(Up.isequal("11")) { double t[] = {0,2./3,0,0,0,0,-1./3,-7./9,0,2./9,1.}; wupf = t[id]; }
+      if(Up.isequal(10)) { double t[] = {0,1./3,0,0,0,1.,2./3,2./9,1.,7./9,0}; wupf = t[id]; }
+      else if(Up.isequal(11)) { double t[] = {0,2./3,0,0,0,0,-1./3,-7./9,0,2./9,1.}; wupf = t[id]; }
    }
-   else if(Wp.isequal("111"))
+   else if(Wp.isequal(111))
    {
-      if(W.isequal("110")&&U.isequal("10")) id=0; UW("110","11",1); UW("200","20",2); UW("111","00",3); UW("111","10",4);
-         UW("111","20",5); UW("210","11",6); UW("210","20",7); UW("210","21",8); UW("211","10",9); UW("211","11",10); 
-	 UW("211","20",11); UW("211","21",12); UW("211","30",13); else { return wupf; }
+      if(W.isequal(110)&&U.isequal(10)) id=0; UW(110,11,1); UW(200,20,2); UW(111,00,3); UW(111,10,4);
+         UW(111,20,5); UW(210,11,6); UW(210,20,7); UW(210,21,8); UW(211,10,9); UW(211,11,10); 
+	 UW(211,20,11); UW(211,21,12); UW(211,30,13); else { return wupf; }
       //           (110)(10)(11) (200)(20) (111)(00)(10)(20) (210)(11)(20)(21)  (211)(10)(11)(20)(21)(30)
       double t[] = { 3./35,    0,    0,    0, -1./7,    0,    0,    0,    0, 27./35,    0,    0,    0,    0,   // (00)
                       2./5, -1./10,  0,  -1., -3./8,   1./8,  0,    0,    0, -9./40,  9./10, 7./8,  0,    0,   // (10)
                     18./35, -9./10,  0,    0, 27./56, -7./8,  0,    0,    0, 1./280, -1./10, 1./8,  1.,   1.}; // (20)
-      if(Up.isequal("00")) { wupf = t[id]; }
-      else if(Up.isequal("10")) { wupf = t[id+14]; }
-      else if(Up.isequal("20")) { wupf = t[id+28]; }
+      if(Up.isequal(00)) { wupf = t[id]; }
+      else if(Up.isequal(10)) { wupf = t[id+14]; }
+      else if(Up.isequal(20)) { wupf = t[id+28]; }
    }
-   else if(Wp.isequal("210"))
+   else if(Wp.isequal(210))
    {
-      if(W.isequal("110")&&U.isequal("10")) id=0; UW("110","11",1); UW("200","20",2); UW("211","10",3); UW("211","11",4);
-         UW("211","20",5); UW("211","21",6); UW("211","30",7); UW("220","20",8); UW("220","21",9); UW("220","22",10); 
+      if(W.isequal(110)&&U.isequal(10)) id=0; UW(110,11,1); UW(200,20,2); UW(211,10,3); UW(211,11,4);
+         UW(211,20,5); UW(211,21,6); UW(211,30,7); UW(220,20,8); UW(220,21,9); UW(220,22,10); 
       else { return wupf; }
       //  WU      (110)(10)(11)  (200)(20)   .--(211)(10)(11)(20)(21)(30)--.     (220)(20)(21)(22)         W'    U'
       double t[] = { 2./5,    0,   2./15, -3./5,    0,    1./3,   3./16,   0,   8./15,   -1./8,    0,  // (210) (11)
                      3./5, 3./35,  9./35,  2./5, 32./35,  2./7, -25./112, 1./7, -16./35, 27./56,   0,  //       (20)
                       0,  32./35, 64./105,  0,   -3./35, -8./21, 33./56,  6./7,  1./105, 11./28,  1.}; //       (21)
-      if(Up.isequal("11")) { wupf = t[id]; }
-      else if(Up.isequal("20")) { wupf = t[id+11]; }
-      else if(Up.isequal("21")) { wupf = t[id+22]; }
+      if(Up.isequal(11)) { wupf = t[id]; }
+      else if(Up.isequal(20)) { wupf = t[id+11]; }
+      else if(Up.isequal(21)) { wupf = t[id+22]; }
    }
-   else if(Wp.isequal("211"))
+   else if(Wp.isequal(211))
    {
-      if(W.isequal("111")&&U.isequal("00")) id=0; UW("111","10",1); UW("111","20",2); UW("210","11",3); UW("210","20",4);
-         UW("210","21",5); UW("211","10",6); UW("211","11",7); UW("211","20",8); UW("211","21",9); UW("211","30",10);
-	 UW("221","10",11); UW("221","11",12); UW("221","20",13); UW("221","21",14); UW("221","30",15); UW("221","31",16); 
+      if(W.isequal(111)&&U.isequal(00)) id=0; UW(111,10,1); UW(111,20,2); UW(210,11,3); UW(210,20,4);
+         UW(210,21,5); UW(211,10,6); UW(211,11,7); UW(211,20,8); UW(211,21,9); UW(211,30,10);
+	 UW(221,10,11); UW(221,11,12); UW(221,20,13); UW(221,21,14); UW(221,30,15); UW(221,31,16); 
       else { return wupf; }
       //   UW     (111)(00)(10)(20)   (210)(11)(20)(21)    (211)(10)(11)(20)(21)(30)      (221)(10)(11)(20)(21)(30)(31)
       double t[] = {1., -1.,    1.,   -7.,   98.,    0,  -5.,  35., -245.,    0,    0,   8.,  35.,    0,     0,   0,   0, // 10
@@ -722,31 +722,31 @@ t=[0   1    0    0   0    0    0    0    0     0     0     0     0     0    0   
                     0,    0, 2560.,   20., -500., 220.,    0,  64., -512.,-176.,  64.,    0,  -1.,   4.,  100.,  7.,  1., // 21
                     0,    0, 3080.,     0,  385., 385.,    0,    0,  616.,  77.,-224.,    0,    0,    0, -343.,  2.,  2.};// 30
       double den[]={1., 24., 5832.,   42., 1701., 672.,  72., 126., 2520., 315., 315.,   9.,  63.,  63., 2016.,  9.,  3.};
-      if(Up.isequal("10")) { wupf = t[id]/den[id]; }
-      else if(Up.isequal("11")) { wupf = t[id+17]/den[id]; }
-      else if(Up.isequal("20")) { wupf = t[id+34]/den[id]; }
-      else if(Up.isequal("21")) { wupf = t[id+51]/den[id]; }
-      else if(Up.isequal("30")) { wupf = t[id+68]/den[id]; }
+      if(Up.isequal(10)) { wupf = t[id]/den[id]; }
+      else if(Up.isequal(11)) { wupf = t[id+17]/den[id]; }
+      else if(Up.isequal(20)) { wupf = t[id+34]/den[id]; }
+      else if(Up.isequal(21)) { wupf = t[id+51]/den[id]; }
+      else if(Up.isequal(30)) { wupf = t[id+68]/den[id]; }
    }
-   else if(Wp.isequal("220"))
+   else if(Wp.isequal(220))
    {
-      if(W.isequal("210")&&U.isequal("11")) id=0; UW("210","20",1); UW("210","21",2); UW("221","10",3); UW("221","11",4);
-         UW("221","20",5); UW("221","21",6); UW("221","30",7); UW("221","31",8); else { return wupf; }
+      if(W.isequal(210)&&U.isequal(11)) id=0; UW(210,20,1); UW(210,21,2); UW(221,10,3); UW(221,11,4);
+         UW(221,20,5); UW(221,21,6); UW(221,30,7); UW(221,31,8); else { return wupf; }
       //   UW         (210)(11)(20)(21)           (221)(10)(11)(20)(21)(30)(31)
       double t[] = { 9./14, -2./7,    9.,    -1., 5./14, 5./7,  -165., -5./14,     0,  // (220) (20)
                     -5./14,  5./7,  880.,      0, 9./14, 2./7, -3888.,  9./14, -1./6,  //       (21)
                          0,     0, 2695.,      0,     0,    0,  1323.,      0,  5./6}; //       (22)
       double den[]={    1.,    1., 3584.,     1.,    1.,   1.,  5376.,     1.,    1.};
-      if(Up.isequal("20")) { wupf = t[id]/den[id]; }
-      else if(Up.isequal("21")) { wupf = t[id+9]/den[id]; }
-      else if(Up.isequal("22")) { wupf = t[id+18]/den[id]; }
+      if(Up.isequal(20)) { wupf = t[id]/den[id]; }
+      else if(Up.isequal(21)) { wupf = t[id+9]/den[id]; }
+      else if(Up.isequal(22)) { wupf = t[id+18]/den[id]; }
    }
-   else if(Wp.isequal("221"))
+   else if(Wp.isequal(221))
    {
-      if(W.isequal("211")&&U.isequal("10")) id=0; UW("211","11",1); UW("211","20",2); UW("211","21",3); UW("211","30",4);
-         UW("220","20",5); UW("220","21",6); UW("220","22",7); UW("221","10",8); UW("221","11",9); UW("221","20",10); 
-	 UW("221","21",11); UW("221","30",12); UW("221","31",13); UW("222","00",14); UW("222","10",15); UW("222","20",16); 
-	 UW("222","30",17); UW("222","40",18); else { return wupf; }
+      if(W.isequal(211)&&U.isequal(10)) id=0; UW(211,11,1); UW(211,20,2); UW(211,21,3); UW(211,30,4);
+         UW(220,20,5); UW(220,21,6); UW(220,22,7); UW(221,10,8); UW(221,11,9); UW(221,20,10); 
+	 UW(221,21,11); UW(221,30,12); UW(221,31,13); UW(222,00,14); UW(222,10,15); UW(222,20,16); 
+	 UW(222,30,17); UW(222,40,18); else { return wupf; }
       //W'                          (221)                                    %  U  W
       //U'    (10)     (11)      (20)       (21)       (30)       (31)       %
       double t[]={4./9, 5./9,     0,         0,         0,         0,        // 10 211
@@ -768,17 +768,17 @@ t=[0   1    0    0   0    0    0    0    0     0     0     0     0     0    0   
               55./972, -77./243,  121./396, -64./243,   14./243,   0,        // 20
               0,        0,        66./462,   128./231, -1./6,      3./22,    // 30
               0,        0,        0,         0,         1./4,      3./4};    // 40
-      if(Up.isequal("10")) { wupf = t[id*6]; }
-      else if(Up.isequal("11")) { wupf = t[id*6+1]; }
-      else if(Up.isequal("20")) { wupf = t[id*6+2]; }
-      else if(Up.isequal("21")) { wupf = t[id*6+3]; }
-      else if(Up.isequal("30")) { wupf = t[id*6+4]; }
-      else if(Up.isequal("31")) { wupf = t[id*6+5]; }
+      if(Up.isequal(10)) { wupf = t[id*6]; }
+      else if(Up.isequal(11)) { wupf = t[id*6+1]; }
+      else if(Up.isequal(20)) { wupf = t[id*6+2]; }
+      else if(Up.isequal(21)) { wupf = t[id*6+3]; }
+      else if(Up.isequal(30)) { wupf = t[id*6+4]; }
+      else if(Up.isequal(31)) { wupf = t[id*6+5]; }
    }
-   else if(Wp.isequal("222"))
+   else if(Wp.isequal(222))
    {
-      if(W.isequal("221")&&U.isequal("10")) id=0; UW("221","11",1); UW("221","20",2); UW("221","21",3); UW("221","30",4);
-         UW("221","31",5); UW("222","00",6); UW("222","10",7); UW("222","20",8); UW("222","30",9); UW("222","40",10); 
+      if(W.isequal(221)&&U.isequal(10)) id=0; UW(221,11,1); UW(221,20,2); UW(221,21,3); UW(221,30,4);
+         UW(221,31,5); UW(222,00,6); UW(222,10,7); UW(222,20,8); UW(222,30,9); UW(222,40,10); 
       else { return wupf; }
       //  W'                       (222)                         %  U  W
       //  U'    (00)     (10)      (20)     (30)     (40)        %
@@ -793,11 +793,11 @@ t=[0   1    0    0   0    0    0    0    0     0     0     0     0     0    0   
                  0,      11./60,  -7./20,    7./15,    0,        // 20
                  0,       0,       9./55,   -3./5,    -13./55,   // 30
                  0,       0,       0,       -1./10,   -9./10};   // 40
-      if(Up.isequal("00")) { wupf = t[id*5]; }
-      else if(Up.isequal("10")) { wupf = t[id*5+1]; }
-      else if(Up.isequal("20")) { wupf = t[id*5+2]; }
-      else if(Up.isequal("30")) { wupf = t[id*5+3]; }
-      else if(Up.isequal("40")) { wupf = t[id*5+4]; }
+      if(Up.isequal(00)) { wupf = t[id*5]; }
+      else if(Up.isequal(10)) { wupf = t[id*5+1]; }
+      else if(Up.isequal(20)) { wupf = t[id*5+2]; }
+      else if(Up.isequal(30)) { wupf = t[id*5+3]; }
+      else if(Up.isequal(40)) { wupf = t[id*5+4]; }
    }
    if(wupf!=0) wupf = sqrt(fabs(wupf))*(wupf/fabs(wupf)); 
    return wupf;

--- a/src/singleion/ic_coulomb.cpp
+++ b/src/singleion/ic_coulomb.cpp
@@ -49,12 +49,12 @@ double racah_xwu(qR7 W, qG2 U, qG2 Up)
    double retval = 0;
    int id;
 
-   if(W.isequal("200"))
+   if(W.isequal(200))
    {
-      if(U.isequal("20") && Up.isequal("20"))
+      if(U.isequal(20) && Up.isequal(20))
          retval = 2;
    }
-   else if (W.isequal("210"))
+   else if (W.isequal(210))
    {
       // Racah IV, Table VII, W = (210)
       // U =          (11)            (20)            (21)       U'
@@ -65,7 +65,7 @@ double racah_xwu(qR7 W, qG2 U, qG2 Up)
       id = ( 2*(Up.u1-1)+Up.u2-1 )*3 + ( 2*(U.u1-1)+U.u2-1 ); 
       retval = t[id];
    }
-   else if (W.isequal("211"))
+   else if (W.isequal(211))
    {
       // Racah IV, Table VIII, W = (211)
       // U =          (10)            (11)            (20)            (21)            (30)       U'
@@ -78,7 +78,7 @@ double racah_xwu(qR7 W, qG2 U, qG2 Up)
       id = ( 2*(Up.u1-1)+Up.u2 )*5 + ( 2*(U.u1-1)+U.u2 ); 
       retval = t[id];
    }
-   else if (W.isequal("220"))
+   else if (W.isequal(220))
    {
       // Racah Table IX, W = (220)
       // U =          (20)           (21)           (22)        U'
@@ -89,7 +89,7 @@ double racah_xwu(qR7 W, qG2 U, qG2 Up)
       id = ( 2*(Up.u1-1)+Up.u2-2 )*3 + ( 2*(U.u1-1)+U.u2-2 ); 
       retval = t[id];
    }
-   else if (W.isequal("221"))
+   else if (W.isequal(221))
    {
       // Racah IV, Table X, W = (221)
       // U =          (10)             (11)            (20)             (21)             (30)            (31)       U'
@@ -103,7 +103,7 @@ double racah_xwu(qR7 W, qG2 U, qG2 Up)
       id = ( 2*(Up.u1-1)+Up.u2 )*6 + ( 2*(U.u1-1)+U.u2 ); 
       retval = t[id];
    }
-   else if (W.isequal("222"))
+   else if (W.isequal(222))
    {
       // Racah IV, Table XI, W = (222)
       // U =          (00)            (10)            (20)            (30)            (40)       U'
@@ -129,7 +129,7 @@ double racah_chi(orbital Lp, orbital L, qG2 U, qG2 Up)
 
    if(abs(L)!=abs(Lp)) { return retval; }     // Numerical values of L must equal - but can have L and Lp different
 
-   if(Up.isequal("31"))      // Use table VIb
+   if(Up.isequal(31))      // Use table VIb
    {
       if(L>0) { id = (L-1) + ( L>3 ? 1 : 0 ) + ( L>5 ? 1 : 0 ) + ( L>6 ? 1 : 0 ) + ( L>7 ? 1 : 0 ); }
       else    { id = (L==-3 ? 3 : 0) + (L!=-3 ? -2*L-4 : 0 ); }
@@ -151,16 +151,16 @@ double racah_chi(orbital Lp, orbital L, qG2 U, qG2 Up)
               0,               0,              0,              0,               0,          1672.,                 0, // N  10 13   9  4
               0,               0,              0,              0,               0,           220.,                 0};// O  11 14  10  4
 
-      if(U.isequal("10")) { retval = t[id*7]; }
-      else if(U.isequal("11")) { retval = t[id*7+1]; }
-      else if(U.isequal("20")) { retval = t[id*7+2]; }
-      else if(U.isequal("21")) { retval = t[id*7+3]; }
-      else if(U.isequal("30")) { retval = t[id*7+4]; }
-      else if(U.isequal("31")) { 
+      if(U.isequal(10)) { retval = t[id*7]; }
+      else if(U.isequal(11)) { retval = t[id*7+1]; }
+      else if(U.isequal(20)) { retval = t[id*7+2]; }
+      else if(U.isequal(21)) { retval = t[id*7+3]; }
+      else if(U.isequal(30)) { retval = t[id*7+4]; }
+      else if(U.isequal(31)) { 
          if(L==Lp) { retval = t[id*7+5]; }
          else      { retval = t[id*7+6]; } }
    }
-   else if(Up.isequal("40")) // Use table VIc
+   else if(Up.isequal(40)) // Use table VIc
    {
 #define CD(c,d) case c: id = d; break
       switch (L) { CD(0,0); CD(2,1); CD(3,2); CD(4,3); CD(-4,4); CD(5,5); CD(6,6); 
@@ -182,7 +182,7 @@ double racah_chi(orbital Lp, orbital L, qG2 U, qG2 Up)
               0,              0,                0,               0,          528.,                 0, // N  10  12
               0,              0,                0,               0,           22.,                 0};// Q  12  13
       
-      if(U.isequal("40")) { if(L==Lp) { retval = t[id*6+4]; } else { retval = t[id*6+5]; } }
+      if(U.isequal(40)) { if(L==Lp) { retval = t[id*6+4]; } else { retval = t[id*6+5]; } }
       else { retval = t[id*6+U.u1]; }
    }
    else                      // Use table VIa 
@@ -204,21 +204,21 @@ double racah_chi(orbital Lp, orbital L, qG2 U, qG2 Up)
            260.,       0,    -25.,      0,     94.,   104.,   -181.,       0,    -36.,       0,    40.}; // 22   22 
 
       if(L>=0) {
-      if(Up.isequal("20") && U.isequal("20")) { retval = t[L]; }
-      else if(Up.isequal("21")) {
-         if(U.isequal("11")) { retval = t[L+11]; }
-	 else if(U.isequal("20")) { retval = t[L+22]; }
-	 else if(U.isequal("21")) { retval = 0; } }
-      else if(Up.isequal("30")) {
-         if(U.isequal("10")) { retval = t[L+55]; }
-	 else if(U.isequal("11")) { retval = t[L+66]; }
-	 else if(U.isequal("20")) { retval = t[L+77]; }
-	 else if(U.isequal("21")) { retval = t[L+88]; }
-	 else if(U.isequal("30")) { retval = t[L+99]; } }
-      else if(Up.isequal("22")) {
-         if(U.isequal("20")) { retval = t[L+110]; }
-	 else if(U.isequal("21")) { retval = t[L+121]; }
-	 else if(U.isequal("22")) { retval = t[L+132]; }
+      if(Up.isequal(20) && U.isequal(20)) { retval = t[L]; }
+      else if(Up.isequal(21)) {
+         if(U.isequal(11)) { retval = t[L+11]; }
+	 else if(U.isequal(20)) { retval = t[L+22]; }
+	 else if(U.isequal(21)) { retval = 0; } }
+      else if(Up.isequal(30)) {
+         if(U.isequal(10)) { retval = t[L+55]; }
+	 else if(U.isequal(11)) { retval = t[L+66]; }
+	 else if(U.isequal(20)) { retval = t[L+77]; }
+	 else if(U.isequal(21)) { retval = t[L+88]; }
+	 else if(U.isequal(30)) { retval = t[L+99]; } }
+      else if(Up.isequal(22)) {
+         if(U.isequal(20)) { retval = t[L+110]; }
+	 else if(U.isequal(21)) { retval = t[L+121]; }
+	 else if(U.isequal(22)) { retval = t[L+132]; }
       }}
    }
    return retval;
@@ -251,12 +251,12 @@ double racah_e2prod(qR7 W, qG2 U, qG2 Up, orbital L, orbital Lp)
 {
    double x1=0,x2=0,c1,c2;
    double retval = 0;
-   if(U.isequal("21") && Up.isequal("21"))
+   if(U.isequal(21) && Up.isequal(21))
    {
-      if(W.isequal("210")) { x1 = (3./7); x2 = 0.; }
-      else if(W.isequal("211")) { x1 = (4./7);  x2 = 3.; }
-      else if(W.isequal("220")) { x1 = (-6./7); x2 = -3.; }
-      else if(W.isequal("221")) { x1 = (-1./7); x2 = (12./11); }
+      if(W.isequal(210)) { x1 = (3./7); x2 = 0.; }
+      else if(W.isequal(211)) { x1 = (4./7);  x2 = 3.; }
+      else if(W.isequal(220)) { x1 = (-6./7); x2 = -3.; }
+      else if(W.isequal(221)) { x1 = (-1./7); x2 = (12./11); }
       switch(L)
       {
          case 0: c1= 0;    c2= 0;    break;
@@ -319,7 +319,7 @@ double racah_yfn(int n, int v, int S2, qG2 U, int vp, qG2 Up)
    
    switch(n)
    {
-      case 2: if(S2==0 && vp==2 && v==2 && U.isequal("20") && Up.isequal("20")) { y = 2; } break;
+      case 2: if(S2==0 && vp==2 && v==2 && U.isequal(20) && Up.isequal(20)) { y = 2; } break;
       case 3: if(S2==1 && vp==3)
               {  // Table XV from Racah IV.
 	         // Up = (11)         (20)               (21)       U
@@ -348,8 +348,8 @@ double racah_yfn(int n, int v, int S2, qG2 U, int vp, qG2 Up)
                               0,      0,      0,         0,       0,  -sqrt(7./80),        0,          1./4};   //  4 0 (22)
 	         if(S2==2) { if(v==2) { id = U.u2*8 + 2*(Up.u1-1)+Up.u2; y = t[id]; }
 		             else if(v==4) { id = (2*(U.u1-1)+U.u2+2)*8 + 2*(Up.u1-1)+Up.u2; y = t[id]; } }
-	         else if(S2==0) { if(v==0 && U.isequal("00")) { y = t[Up.u2+61]; } 
-		             else if(v==2 && U.isequal("20")) { y = t[Up.u2+69]; }
+	         else if(S2==0) { if(v==0 && U.isequal(00)) { y = t[Up.u2+61]; } 
+		             else if(v==2 && U.isequal(20)) { y = t[Up.u2+69]; }
 		             else if(v==4) { id = (U.u2+9)*8 + Up.u2+5; y = t[id]; } }
 	      } break;
       case 5: if(vp==5)
@@ -448,7 +448,7 @@ double racah_phi(qG2 U, qG2 Up, orbital Lp, orbital L)
    double retval=0;
    int id;
 
-   if(Up.isequal("31"))
+   if(Up.isequal(31))
    {  //  Table XIVb from Racah IV. U' = (31)
       //  U = (10)   (11)         (21)         (30)              (31)               (31)'      L  Lnum id
       double t[]={0,sqrt(330.),     0,    17*sqrt(143.),         209.,                 0,  //  P   1   0
@@ -468,13 +468,13 @@ double racah_phi(qG2 U, qG2 Up, orbital Lp, orbital L)
               0,      0,            0,           0,              352.,                 0}; //  O  11  14
       switch (L) { CD(1,0); CD(2,1); CD(3,2); CD(-3,3); CD(4,4); CD(5,5); CD(-5,6); CD(6,7); 
                    CD(-6,8); CD(7,9); CD(-7,10); CD(8,11); CD(9,12); CD(10,13); CD(11,14); default: return retval; }
-      if(U.isequal("31")) { if(L==Lp) { retval = t[id*6+4]; } else { retval = t[id*6+5]; } }
-      else if(U.isequal("30")) { retval = t[id*6+3]; } 
-      else if(U.isequal("21")) { retval = t[id*6+2]; }
-      else if(U.isequal("11")) { retval = t[id*6+1]; }
-      else if(U.isequal("10")) { retval = t[id*6]; }
+      if(U.isequal(31)) { if(L==Lp) { retval = t[id*6+4]; } else { retval = t[id*6+5]; } }
+      else if(U.isequal(30)) { retval = t[id*6+3]; } 
+      else if(U.isequal(21)) { retval = t[id*6+2]; }
+      else if(U.isequal(11)) { retval = t[id*6+1]; }
+      else if(U.isequal(10)) { retval = t[id*6]; }
    }
-   else if(Up.isequal("40"))
+   else if(Up.isequal(40))
    {  //  Table XIVc from Racah IV. Up=(40)
       //  U =       (20)               (21)               (22)       L Lnum id
       double t[] = {   0,                 0,     2*sqrt(2145.),  //  S   0   0
@@ -491,9 +491,9 @@ double racah_phi(qG2 U, qG2 Up, orbital Lp, orbital L)
                        0,  -84*sqrt(19./31),       sqrt(2530.)}; //  N  10  11
       switch (L) { CD(0,0); CD(2,1); CD(3,2); CD(4,3); CD(-4,4); CD(5,5); CD(6,6); 
                    CD(-6,7); CD(7,8); CD(8,9); CD(-8,10); CD(10,11); default: return retval; }
-      if(U.isequal("20")) { retval = t[id*3]; }
-      else if(U.isequal("21")) { retval = t[id*3+1]; }
-      else if(U.isequal("22")) { retval = t[id*3+2]; }
+      if(U.isequal(20)) { retval = t[id*3]; }
+      else if(U.isequal(21)) { retval = t[id*3+1]; }
+      else if(U.isequal(22)) { retval = t[id*3+2]; }
    }
    else if(L>=0)
    {  //  Table XIVa from Racah IV.
@@ -513,31 +513,31 @@ double racah_phi(qG2 U, qG2 Up, orbital Lp, orbital L)
              1.,      0,      0,        0,        0,       0,       0,       0,      0,    0,    0,  // (00) (22)
               0,      0,3*sqrt(429.),   0, 4*sqrt(65.),    0, 3*sqrt(85.),   0,      0,    0,    0,  // (20) (22)
            144.,      0,     69.,       0,     -148.,    72.,     39.,       0,   -96.,    0,  56.}; // (22) (22)
-      if(U.isequal("11") && Up.isequal("11")) { retval = t[L]; }
-      else if(Up.isequal("20")) 
+      if(U.isequal(11) && Up.isequal(11)) { retval = t[L]; }
+      else if(Up.isequal(20)) 
       { 
-         if (U.isequal("20")) { retval = t[L+11]; } 
-	 else if(U.isequal("21")) { retval = t[L+22]; }
+         if (U.isequal(20)) { retval = t[L+11]; } 
+	 else if(U.isequal(21)) { retval = t[L+22]; }
       }
-      else if(Up.isequal("10") && U.isequal("21")) { retval = t[L+33]; }
-      else if(Up.isequal("21")) 
+      else if(Up.isequal(10) && U.isequal(21)) { retval = t[L+33]; }
+      else if(Up.isequal(21)) 
       { 
-         if (U.isequal("10")) { retval = t[L+33]; } 
-	 else if(U.isequal("20")) { retval = t[L+44]; }
-	 else if(U.isequal("21")) { retval = t[L+55]; }
+         if (U.isequal(10)) { retval = t[L+33]; } 
+	 else if(U.isequal(20)) { retval = t[L+44]; }
+	 else if(U.isequal(21)) { retval = t[L+55]; }
       }
-      else if(Up.isequal("30")) 
+      else if(Up.isequal(30)) 
       { 
-         if (U.isequal("11")) { retval = t[L+66]; }
-	 else if(U.isequal("20")) { retval = t[L+77]; }
-	 else if(U.isequal("21")) { retval = t[L+88]; }
-	 else if(U.isequal("30")) { retval = t[L+99]; }
+         if (U.isequal(11)) { retval = t[L+66]; }
+	 else if(U.isequal(20)) { retval = t[L+77]; }
+	 else if(U.isequal(21)) { retval = t[L+88]; }
+	 else if(U.isequal(30)) { retval = t[L+99]; }
       }
-      else if(Up.isequal("22")) 
+      else if(Up.isequal(22)) 
       { 
-         if (U.isequal("00")) { retval = t[L+110]; } 
-         else if(U.isequal("20")) { retval = t[L+121]; }
-	 else if(U.isequal("22")) { retval = t[L+132]; }
+         if (U.isequal(00)) { retval = t[L+110]; } 
+         else if(U.isequal(20)) { retval = t[L+121]; }
+	 else if(U.isequal(22)) { retval = t[L+132]; }
       }
    }
    return retval;
@@ -844,7 +844,7 @@ RowMatrixXd racah_ci(int n, double alpha)                                // For 
    //Up.set(1,1); std::vector<numdenom> xwu2 = racah_xwu(W,U,Up);
    //xwu = xwu2; std::cout << xwu[0] << ", " << xwu[1] << "\n";
    
-   //qG2 U(0,0); std::cout << U.isequal("00") << "\n";
+   //qG2 U(0,0); std::cout << U.isequal(00) << "\n";
    //qG2 Up(2,2);
    //std::cout << racah_phi(U,Up,S,S) << "\n";
    //std::vector< std::vector<double> > e2 = racah_e2(2);

--- a/src/singleion/ic_states.cpp
+++ b/src/singleion/ic_states.cpp
@@ -116,27 +116,27 @@ int qR7::set(int w1_, int w2_, int w3_)
 
 bool qR7::operator == (const qR7 & wp) const
 {
-   if (w1==wp.w1 && w2==wp.w2 && w3==wp.w3) { return true; }
-   else { return false; }
+   return (w1==wp.w1 && w2==wp.w2 && w3==wp.w3);
 }
 
 bool qR7::operator != (const qR7 & wp) const
 {
-   if (w1!=wp.w1 || w2!=wp.w2 || w3!=wp.w3) { return true; }
-   else { return false; }
+   return (w1!=wp.w1 || w2!=wp.w2 || w3!=wp.w3);
 }
 
-bool qR7::isequal (const char * Wstr)
+bool qR7::isequal (int w)
 {
-   char ws=0;
-   int  w1n=0,w2n=1,w3n=2;
-
-   ws = Wstr[0]; w1n = atoi(&ws);
-   ws = Wstr[1]; w2n = atoi(&ws);
-   ws = Wstr[2]; w3n = atoi(&ws);
-
-   if (w1==w1n && w2==w2n && w3==w3n) { return true; }
-   else { return false; }
+   // In C++ a literal beginning with 0 is octal
+   if (w > 99) {  // Decimal literal
+      std::div_t w1d = std::div(w, 100);
+      std::div_t w2d = std::div(w1d.rem, 10);
+      return (w1==w1d.quot && w2==w2d.quot && w3==w2d.rem);
+   } else if (w > 0) {  // Octal literal, w1=0
+      std::div_t w2d = std::div(w, 8);
+      return (w1==0 && w2==w2d.quot && w3==w2d.rem);
+   } else {
+      return (w1==0 && w2==0 && w3==0);
+   }
 }
 
 // --------------------------------------------------------------------------------------------------------------- //
@@ -149,26 +149,24 @@ int qG2::set(int u1_, int u2_)
 
 bool qG2::operator == (const qG2 & up) const
 {
-   if (u1==up.u1 && u2==up.u2) { return true; }
-   else { return false; }
+   return (u1==up.u1 && u2==up.u2);
 }
 
 bool qG2::operator != (const qG2 & up) const
 {
-   if (u1!=up.u1 || u2!=up.u2) { return true; }
-   else { return false; }
+   return (u1!=up.u1 || u2!=up.u2);
 }
 
-bool qG2::isequal (const char * Ustr)
+bool qG2::isequal (int u)
 {
-   char us=0;
-   int  u1n=0,u2n=1;
-
-   us = Ustr[0]; u1n = atoi(&us);
-   us = Ustr[1]; u2n = atoi(&us);
-
-   if (u1==u1n && u2==u2n) { return true; }
-   else { return false; }
+   if (u > 9) {  // Decimal literal
+      std::div_t u1d = std::div(u, 10);
+      return (u1==u1d.quot && u2==u1d.rem);
+   } else if (u > 0) {  // Octal literal
+      return (u1==0 && u2==u);
+   } else {
+      return (u1==0 && u2==0);
+   }
 }
 
 // --------------------------------------------------------------------------------------------------------------- //
@@ -861,7 +859,7 @@ void fconf::set(int n, bool mJflag, orbital l)
              << ", U=[" << conf.states[0].U.u1 << " " << conf.states[0].U.u2
 	     << "], W=[" << conf.states[0].W.w1 << " " << conf.states[0].W.w2 << " " << conf.states[0].W.w3 << "]\n";
 
-   WisW = conf.states[0].W.isequal("100");
+   WisW = conf.states[0].W.isequal(100);
    //fprintf(stdout,"W=[%i %i %i] == [1 0 0] is %s\n",conf.states[0].W.w1,conf.states[0].W.w2,conf.states[0].W.w3,
    //        WisW ? "true" : "false");
    std::cout << "W=[" << conf.states[0].W.w1 << " " << conf.states[0].W.w2 << " " << conf.states[0].W.w3

--- a/src/singleion/ic_tensorops.cpp
+++ b/src/singleion/ic_tensorops.cpp
@@ -22,7 +22,7 @@ static const std::array<int, 51> q = {0,0,0,0,0,0,-2,-1,0,1,2,-3,-2,-1,0,1,2,3,-
 // Calculates the tensor operators up to 
 // --------------------------------------------------------------------------------------------------------------- //
 void ic1ion::calc_tensorops(int num_op) {
-    if (num_op < m_tensorops.size() && num_op <= 0)
+    if (num_op < m_tensorops.size() || num_op <= 0)
         return;
     // Calculates the L and S operator matrix for the each directions
     // Note operators up to 6 are the magnetic moment operators in x, y, z basis 
@@ -33,6 +33,7 @@ void ic1ion::calc_tensorops(int num_op) {
     racah_mumat(-1, Lm1, Sm1);
     // Note also that m_tensorops is a vector of _real_ matrices.
     // BUT negative order (-q) operators are purely imaginary, as are the Sy and Ly matrices.
+    m_tensorops.clear();
     m_tensorops.push_back((Sm1 - Sp1) / sqrt(2.));  // Sx
     m_tensorops.push_back((Lm1 - Lp1) / sqrt(2.));  // Lx
     m_tensorops.push_back((Sm1 + Sp1) / sqrt(2.));  // Sy
@@ -56,7 +57,7 @@ RowMatrixXcd ic1ion::zeeman_hamiltonian(double H, std::vector<double> Hdir) {
     // Normalise the field direction vector
     double Hnorm = sqrt(Hdir[0] * Hdir[0] + Hdir[1] * Hdir[1] + Hdir[2] * Hdir[2]);
     if (fabs(Hnorm) < 1.e-6) {
-        throw std::runtime_error("ic1ion::magnetisation(): Direction vector cannot be zero");
+        throw std::runtime_error("ic1ion::zeeman_hamiltonian(): Direction vector cannot be zero");
     }
     std::vector<double> nHdir;
     std::transform(Hdir.begin(), Hdir.end(), std::back_inserter(nHdir), [Hnorm](double Hd){ return Hd / Hnorm; });

--- a/src/singleion/ic_tensorops.cpp
+++ b/src/singleion/ic_tensorops.cpp
@@ -85,20 +85,6 @@ std::vector<RowMatrixXcd> ic1ion::calculate_moments_matrix(RowMatrixXcd ev) {
     return moments;
 }
 
-std::vector< std::vector<double> > ic1ion::calculate_moments(RowMatrixXcd ev) {
-    std::vector<RowMatrixXcd> mommat = calculate_moments_matrix(ev);
-    std::vector< std::vector<double> > moments_diag;
-    for (auto mom: mommat) {
-        std::vector<double> moment_vec;
-        for (int ii=0; ii<ev.cols(); ii++) {
-            moment_vec.push_back(mom(ii, ii).real());
-        }
-        moments_diag.push_back(moment_vec);
-    }
-    return moments_diag;
-}
-
-
 /*
 // --------------------------------------------------------------------------------------------------------------- //
 // Calculates the mean field matrix sum_i (H_i*J_i)

--- a/src/singleion/ic_tensorops.cpp
+++ b/src/singleion/ic_tensorops.cpp
@@ -66,7 +66,7 @@ RowMatrixXcd ic1ion::zeeman_hamiltonian(double H, std::vector<double> Hdir) {
     zeeman.real() = (GS * m_tensorops[0] + m_tensorops[1]) * nHdir[0]   // gSx + Lx
                    +(GS * m_tensorops[4] + m_tensorops[5]) * nHdir[2];  // gSz + Lz
     zeeman.imag() = (GS * m_tensorops[2] + m_tensorops[3]) * nHdir[1];  // gSy + Ly
-    double H_in_energy = H * MU_B * m_econv; // MU_B in internal units (cm/T); want H in external energy units
+    double H_in_energy = H * MU_Bc * m_econv; // MU_B in internal units (cm/T); want H in external energy units
     return (zeeman * H_in_energy);
 }
 

--- a/src/singleion/physprop.cpp
+++ b/src/singleion/physprop.cpp
@@ -1,0 +1,173 @@
+/* physprop.cpp
+ * 
+ * A class for calculating the physical properties (magnetisation, susceptibility, heat capacity) associated with
+ * a crystal field type single-ion Hamiltonian.
+ *
+ * (C) 2024 Duc Le - duc.le@stfc.ac.uk
+ * This program is licensed under the GNU General Purpose License, version 3. Please see the LICENSE file
+ */
+
+#include "physprop.hpp"
+#include "eigen.hpp"
+
+namespace libMcPhase {
+
+// --------------------------------------------------------------------------------------------------------------- //
+// Calculates bulk properties (heat capacity, magnetisation, susceptibility)
+// --------------------------------------------------------------------------------------------------------------- //
+
+std::vector<double> physprop::calculate_boltzmann(VectorXd en, double T) // Note that energy must be in meV in this routine
+{
+    std::vector<double> boltzmann;
+    // Need kBT in external energy units. K_B is in cm-1/K
+    double kBT = K_B * T * m_meVconv;
+    double Emin = std::numeric_limits<double>::max();
+    for (size_t i=0; i < (size_t)en.size(); i++) {
+        Emin = (en(i) < Emin) ? en(i) : Emin;
+    }
+    for (size_t i=0; i < (size_t)en.size(); i++) {
+        const double expi = exp(-(en(i) - Emin) / kBT);
+        boltzmann.push_back((fabs(expi) > DELTA_EPS) ? expi : 0.);
+    }
+    return boltzmann;
+}
+
+std::vector<double> physprop::heatcapacity(std::vector<double> Tvec) {
+    auto es = eigensystem();
+    std::vector<double> out;
+    out.reserve(Tvec.size());
+    std::vector<double> en;
+    double Emin = std::numeric_limits<double>::max();
+    size_t sz = std::get<1>(es).size();
+    en.reserve(sz);
+    for (size_t i=0; i < sz; i++) {
+        en.push_back(std::get<1>(es)(i) / m_meVconv);
+        Emin = (en[i] < Emin) ? en[i] : Emin;
+    }
+    for (size_t i=0; i < sz; i++) {
+        en[i] -= Emin;
+    }
+    for (auto T: Tvec) {
+        double Z = 0., U = 0., U2 = 0.;
+        std::vector<double> expfact = calculate_boltzmann(std::get<1>(es), T);
+        for (size_t i=0; i < sz; i++) {
+            Z += expfact[i];
+            U += en[i] * expfact[i];
+            U2 += en[i] * en[i] * expfact[i];
+        }
+        U /= Z;
+        U2 /= Z;
+        out.push_back( ((U2 - U * U) / (K_B * T * T)) * NAMEV );
+    }
+    return out;
+}
+
+
+std::vector< std::vector<double> > physprop::calculate_moments(RowMatrixXcd ev) {
+    std::vector<RowMatrixXcd> mommat = calculate_moments_matrix(ev);
+    std::vector< std::vector<double> > moments_diag;
+    for (auto mom: mommat) {
+        std::vector<double> moment_vec;
+        for (int ii=0; ii<ev.cols(); ii++) {
+            moment_vec.push_back(mom(ii, ii).real());
+        }
+        moments_diag.push_back(moment_vec);
+    }
+    return moments_diag;
+}
+
+std::vector<double> physprop::magnetisation(std::vector<double> Hvec, std::vector<double> Hdir, double T, MagUnits unit_type)
+{
+    // Normalise the field direction vector
+    double Hnorm = sqrt(Hdir[0] * Hdir[0] + Hdir[1] * Hdir[1] + Hdir[2] * Hdir[2]);
+    if (fabs(Hnorm) < 1.e-6) {
+        throw std::runtime_error("physprop::magnetisation(): Direction vector cannot be zero");
+    }
+    std::vector<double> nHdir;
+    std::transform(Hdir.begin(), Hdir.end(), std::back_inserter(nHdir), [Hnorm](double Hd){ return Hd / Hnorm; });
+    // Calculates Magnetisation M(H) at specified T
+    RowMatrixXcd ham0 = hamiltonian();
+    std::vector<double> M;
+    M.reserve(Hvec.size());
+    // Loops through all the input field magnitudes and calculates the magnetisation
+    for (auto H: Hvec) {
+        if (unit_type == MagUnits::cgs) {
+            H /= 1e4;   // For cgs, input field is in Gauss, need to convert to Tesla for Zeeman calculation
+        }
+        RowMatrixXcd ham = ham0 - zeeman_hamiltonian(H, Hdir);
+        SelfAdjointEigenSolver<RowMatrixXcd> es(ham);
+        // calculate_moments returns a vector of 3 moments *squared* vectors, in the x, y, z directions
+        std::vector< std::vector<double> > moments_vec = calculate_moments(es.eigenvectors());
+        std::vector<double> boltzmann = calculate_boltzmann(es.eigenvalues(), T);
+        std::vector<double> Mdir;
+        for (auto moments: moments_vec) {
+            double Mexp = 0., Z = 0.;
+            //std::inner_product(moments.begin(), moments.end(), boltzmann.begin(), Mexp);
+            //std::accumulate(boltzmann.begin(), boltzmann.end(), Z);
+            for (int ii=0; ii<ham.cols(); ii++) {
+                Mexp += moments[ii] * boltzmann[ii];
+                Z += boltzmann[ii];
+            }
+            Mdir.push_back(Mexp / Z);
+        }
+        M.push_back(sqrt(Mdir[0] * Mdir[0] + Mdir[1] * Mdir[1] + Mdir[2] * Mdir[2]) * MAGCONV[(int)unit_type]);
+    }
+    return M;
+}
+
+std::vector<double> physprop::susceptibility(std::vector<double> Tvec, std::vector<double> Hdir, MagUnits unit_type)
+{
+    // Normalise the field direction vector
+    double Hnorm = sqrt(Hdir[0] * Hdir[0] + Hdir[1] * Hdir[1] + Hdir[2] * Hdir[2]);
+    if (fabs(Hnorm) < 1.e-6) {
+        throw std::runtime_error("physprop::magnetisation(): Direction vector cannot be zero");
+    }
+    std::vector<double> nHdir;
+    std::transform(Hdir.begin(), Hdir.end(), std::back_inserter(nHdir), [Hnorm](double Hd){ return Hd / Hnorm; });
+    // Calculates the susceptibility chi(T)
+    std::tuple<RowMatrixXcd, VectorXd> es = eigensystem();
+    std::vector<double> chi;
+    chi.reserve(Tvec.size());
+    // Calculates the moments matrices in the x, y, z directions, and get the resultant
+    std::vector<RowMatrixXcd> moments_mat_vec = calculate_moments_matrix(std::get<0>(es));
+    RowMatrixXcd moments_mat = moments_mat_vec[0] * nHdir[0]
+                               + moments_mat_vec[1] * nHdir[1]
+                               + moments_mat_vec[2] * nHdir[2];
+    // Now calculate the first and second order terms in the Van Vleck equation
+    size_t nlev = std::get<0>(es).cols();
+    std::vector<double> mu(nlev, 0.);
+    std::vector<double> mu2(nlev, 0.);
+    VectorXd eigenvalues = std::get<1>(es);
+    for (size_t ii=0; ii<nlev; ii++) {
+        for (size_t jj=0; jj<nlev; jj++) {
+            const double delta = eigenvalues[ii] - eigenvalues[jj];
+            const double matel = (moments_mat(ii, jj) * std::conj(moments_mat(ii, jj))).real();
+            if (fabs(delta) < DELTA_EPS) {
+                mu[ii] += matel;           // First order term
+            } else {
+                mu2[ii] += matel / delta;  // Second order term
+            }
+        }
+    }
+
+    // Loops through all the input temperatures and calculates the susceptibility using:
+    //                                 2                     2
+    //           N_A --- [ <V_n|mu|V_n>      --- <V_n|mu|V_m>  ]
+    // chi(T) =  --- >   [ ------------  - 2 >   ------------  ] exp(-E/k_BT)
+    //            Z  --- [    k_B T          ---   En - Em     ]
+    //                n                     m!=n
+
+    for (auto T: Tvec) {
+        std::vector<double> boltzmann = calculate_boltzmann(eigenvalues, T);
+        const double beta = 1. / (K_B * T);
+        double U = 0., Z = 0.;
+        for (size_t ii=0; ii<nlev; ii++) {
+            U += ((mu[ii] * beta) - (2 * mu2[ii])) * boltzmann[ii];
+            Z += boltzmann[ii];
+        }
+        chi.push_back(SUSCCONV[(int)unit_type] * U / Z);
+    }
+    return chi;
+}
+
+} // namespace libMcPhase

--- a/tests/test_cf1ion.py
+++ b/tests/test_cf1ion.py
@@ -90,16 +90,22 @@ class cf1ionTests(unittest.TestCase):
         V, E = cfp.eigensystem()
         nptest.assert_allclose(E - E[0], self.en_ref_l, atol=1e-4)
 
-#    def test_physical_properties(self):
-#        # Compared to values from Mantid
-#        cf = libmcphase.cf1ion('Ce3+', B20=0.37737, B22=3.9770, B40=-0.031787, B42=-0.11611, B44=-0.12544)
-#        # Test Heat capacity calculations
-#        TCv, Cv = cf.getHeatCapacity()
-#        self.assertAlmostEqual(TCv[150], 151, 4)
-#        self.assertAlmostEqual(Cv[100], 4.2264, 3)
-#        self.assertAlmostEqual(Cv[150], 5.9218, 3)
-#        self.assertAlmostEqual(Cv[200], 5.4599, 3)
-#
+    def test_physical_properties(self):
+        # Compared to values from Mantid
+        cfpars = {'B20':0.37737, 'B22':3.9770, 'B40':-0.031787, 'B42':-0.11611, 'B44':-0.12544}
+        cf = libmcphase.cf1ion('Ce3+', **cfpars)
+        # Test Heat capacity calculations
+        Cv = cf.heatcapacity(np.linspace(1,300,300))
+        #self.assertAlmostEqual(TCv[150], 151, 4)
+        self.assertAlmostEqual(Cv[100], 4.2264, 3)
+        self.assertAlmostEqual(Cv[150], 5.9218, 3)
+        self.assertAlmostEqual(Cv[200], 5.4599, 3)
+        cf = libmcphase.cf1ion('Ce3+', **{k:v*11.6045 for k,v in cfpars.items()}, unit='K')
+        Cv = cf.heatcapacity(np.linspace(1,300,300))
+        self.assertAlmostEqual(Cv[100], 4.2264, 3)
+        self.assertAlmostEqual(Cv[150], 5.9218, 3)
+        self.assertAlmostEqual(Cv[200], 5.4599, 3)
+
 #        # Test susceptibility calculations
 #        Tchi_powder, chi_powder = cf.getSusceptibility(np.linspace(1, 300, 50), Hdir="powder")
 #        self.assertAlmostEqual(Tchi_powder[10], 62.02, 2)

--- a/tests/test_cf1ion.py
+++ b/tests/test_cf1ion.py
@@ -113,7 +113,7 @@ class cf1ionTests(unittest.TestCase):
         cf = libmcphase.cf1ion('Ce3+', **self.pp_cfpars)
         #Tchi_powder, chi_powder = cf.getSusceptibility(np.linspace(1, 300, 50), Hdir="powder")
         tt = np.linspace(1, 300, 50)
-        cc = [np.array(cf.susceptibility(tt, hdir, 'cgs')) for hdir in [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]]
+        cc = [cf.susceptibility(tt, hdir, 'cgs') for hdir in [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]]
         chi_powder = (cc[0] + cc[1] + cc[2]) / 3
         #self.assertAlmostEqual(Tchi_powder[10], 62.02, 2)
         self.assertAlmostEqual(chi_powder[5], 1.92026e-2, 6)
@@ -125,8 +125,8 @@ class cf1ionTests(unittest.TestCase):
         cf = libmcphase.cf1ion('Ce3+', **self.pp_cfpars)
         tt = np.linspace(1, 300, 50)
         #Tmt_powder, mt_powder = cf.getMagneticMoment(1.0, Temperature=np.linspace(1, 300, 50), Hdir="powder", Unit="cgs")
-        cc = [np.array(cf.susceptibility(tt, hdir, 'cgs')) for hdir in [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]]
-        mm = [np.array(cf.magnetisation([1.0], hdir, tt, 'cgs')) for hdir in [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]]
+        cc = [cf.susceptibility(tt, hdir, 'cgs') for hdir in [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]]
+        mm = [cf.magnetisation([1.0], hdir, tt, 'cgs') for hdir in [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]]
         chi_powder = (cc[0] + cc[1] + cc[2]) / 3
         mt_powder = np.squeeze(mm[0] + mm[1] + mm[2]) / 3
         self.assertAlmostEqual(chi_powder[5], mt_powder[5], 6)
@@ -139,13 +139,13 @@ class cf1ionTests(unittest.TestCase):
 
         # Test different Hmag
         #_, h_mag_10 = cf.getMagneticMoment(Hmag=10, Temperature=np.linspace(1, 300, 50), Hdir="powder", Unit="bohr")
-        mm = [np.array(cf.magnetisation([10.], hdir, tt, 'bohr')) for hdir in [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]]
+        mm = [cf.magnetisation([10.], hdir, tt, 'bohr') for hdir in [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]]
         h_mag_10 = np.squeeze(mm[0] + mm[1] + mm[2]) / 3
         self.assertAlmostEqual(h_mag_10[5], 0.323607, 5)
         self.assertAlmostEqual(h_mag_10[10], 0.182484, 5)
         self.assertAlmostEqual(h_mag_10[15], 0.129909, 5)
         #_, h_mag_5 = cf.getMagneticMoment(Hmag=5, Temperature=np.linspace(1, 300, 50), Hdir="powder", Unit="bohr")
-        mm = [np.array(cf.magnetisation([5.], hdir, tt, 'bohr')) for hdir in [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]]
+        mm = [cf.magnetisation([5.], hdir, tt, 'bohr') for hdir in [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]]
         h_mag_5 = np.squeeze(mm[0] + mm[1] + mm[2]) / 3
         self.assertAlmostEqual(h_mag_5[5], 0.16923426, 6)
         self.assertAlmostEqual(h_mag_5[10], 0.09228022, 6)

--- a/tests/test_cf1ion.py
+++ b/tests/test_cf1ion.py
@@ -53,6 +53,9 @@ class cf1ionTests(unittest.TestCase):
                  'B66S':-6.6456e-04, 'B65S':8.0453e-04, 'B64S':3.4691e-04, 'B63S':5.1962e-04, 'B62S':-1.2112e-04, 'B61S':3.5266e-05}
     all_pars = dict(pars_real, **pars_imag)
 
+    # Parameters for physical properties check
+    pp_cfpars = {'B20':0.37737, 'B22':3.9770, 'B40':-0.031787, 'B42':-0.11611, 'B44':-0.12544}
+
     def test_creation_and_diagonalisation(self):
         with self.assertRaises(RuntimeError):   # J must be integer or half-integer
             cfp = libmcphase.cf1ion(2.3)
@@ -90,30 +93,33 @@ class cf1ionTests(unittest.TestCase):
         V, E = cfp.eigensystem()
         nptest.assert_allclose(E - E[0], self.en_ref_l, atol=1e-4)
 
-    def test_physical_properties(self):
+    def test_heatcapacity(self):
         # Compared to values from Mantid
-        cfpars = {'B20':0.37737, 'B22':3.9770, 'B40':-0.031787, 'B42':-0.11611, 'B44':-0.12544}
-        cf = libmcphase.cf1ion('Ce3+', **cfpars)
+        cf = libmcphase.cf1ion('Ce3+', **self.pp_cfpars)
         # Test Heat capacity calculations
         Cv = cf.heatcapacity(np.linspace(1,300,300))
         #self.assertAlmostEqual(TCv[150], 151, 4)
         self.assertAlmostEqual(Cv[100], 4.2264, 3)
         self.assertAlmostEqual(Cv[150], 5.9218, 3)
         self.assertAlmostEqual(Cv[200], 5.4599, 3)
-        cf = libmcphase.cf1ion('Ce3+', **{k:v*11.6045 for k,v in cfpars.items()}, unit='K')
+        cf = libmcphase.cf1ion('Ce3+', **{k:v*11.6045 for k,v in self.pp_cfpars.items()}, unit='K')
         Cv = cf.heatcapacity(np.linspace(1,300,300))
         self.assertAlmostEqual(Cv[100], 4.2264, 3)
         self.assertAlmostEqual(Cv[150], 5.9218, 3)
         self.assertAlmostEqual(Cv[200], 5.4599, 3)
 
+#    def test_susceptibility(self):
 #        # Test susceptibility calculations
+#        cf = libmcphase.cf1ion('Ce3+', **self.pp_cfpars)
 #        Tchi_powder, chi_powder = cf.getSusceptibility(np.linspace(1, 300, 50), Hdir="powder")
 #        self.assertAlmostEqual(Tchi_powder[10], 62.02, 2)
 #        self.assertAlmostEqual(chi_powder[5], 1.92026e-2, 6)
 #        self.assertAlmostEqual(chi_powder[10], 1.03471e-2, 6)
 #        self.assertAlmostEqual(chi_powder[15], 0.73004e-2, 6)
 #
+#    def test_magnetisation_vs_T(self):
 #        # Test M(T) calculations
+#        cf = libmcphase.cf1ion('Ce3+', **self.pp_cfpars)
 #        Tmt_powder, mt_powder = cf.getMagneticMoment(1.0, Temperature=np.linspace(1, 300, 50), Hdir="powder", Unit="cgs")
 #        self.assertAlmostEqual(chi_powder[5], mt_powder[5], 6)
 #        self.assertAlmostEqual(chi_powder[10], mt_powder[10], 6)
@@ -133,7 +139,9 @@ class cf1ionTests(unittest.TestCase):
 #        self.assertAlmostEqual(h_mag_5[10], 0.09228022, 6)
 #        self.assertAlmostEqual(h_mag_5[15], 0.06525625, 6)
 #
+#    def test_magnetisation(self):
 #        # Test M(H) calculations
+#        cf = libmcphase.cf1ion('Ce3+', **self.pp_cfpars)
 #        Hmag_SI, mag_SI = cf.getMagneticMoment(np.linspace(0, 30, 15), Temperature=10, Hdir=[0, 1, -1], Unit="SI")
 #        self.assertAlmostEqual(mag_SI[1], 1.8139, 3)
 #        self.assertAlmostEqual(mag_SI[5], 6.7859, 3)

--- a/tests/test_cf1ion.py
+++ b/tests/test_cf1ion.py
@@ -1,4 +1,4 @@
-import libmcphase as libMcPhase
+import libmcphase
 import unittest
 import numpy as np
 import numpy.testing as nptest
@@ -55,11 +55,11 @@ class cf1ionTests(unittest.TestCase):
 
     def test_creation_and_diagonalisation(self):
         with self.assertRaises(RuntimeError):   # J must be integer or half-integer
-            cfp = libMcPhase.cf1ion(2.3)
+            cfp = libmcphase.cf1ion(2.3)
         with self.assertRaises(RuntimeError):   # Unknown ion name (must be a rare earth 3+)
-            cfp = libMcPhase.cf1ion('Pd3+')
+            cfp = libmcphase.cf1ion('Pd3+')
         # Random parameters, compared to results from Saficf and cfield
-        cfp = libMcPhase.cf1ion('Pr3+', **self.pars_real)
+        cfp = libmcphase.cf1ion('Pr3+', **self.pars_real)
         nptest.assert_allclose(cfp.hamiltonian(), self.ham_ref, rtol=1e-4)
         V, E = cfp.eigensystem()
         nptest.assert_allclose(E, self.eval_refr, atol=1e-4)
@@ -67,7 +67,7 @@ class cf1ionTests(unittest.TestCase):
         nptest.assert_allclose(V @ np.diag(E) @ V.conj().T, cfp.hamiltonian(), atol=1e-4)
 
     def test_imaginary_parameters(self):
-        cfp = libMcPhase.cf1ion('Pr3+', **self.pars_imag)
+        cfp = libmcphase.cf1ion('Pr3+', **self.pars_imag)
         nptest.assert_allclose(cfp.hamiltonian(), 1j*self.ham_refi, rtol=1e-4)
         V, E = cfp.eigensystem()
         nptest.assert_allclose(E, self.eval_refi, atol=1e-4)
@@ -75,7 +75,7 @@ class cf1ionTests(unittest.TestCase):
         nptest.assert_allclose(V @ np.diag(E) @ V.conj().T, cfp.hamiltonian(), atol=1e-4)
 
     def test_all_parameters(self):
-        cfp = libMcPhase.cf1ion('Pr3+', **self.all_pars)
+        cfp = libmcphase.cf1ion('Pr3+', **self.all_pars)
         nptest.assert_allclose(cfp.hamiltonian(), self.ham_ref + 1j*self.ham_refi, rtol=1e-4)
         V, E = cfp.eigensystem()
         nptest.assert_allclose(E, self.eval_reff, atol=1e-4)
@@ -83,9 +83,56 @@ class cf1ionTests(unittest.TestCase):
         nptest.assert_allclose(V @ np.diag(E) @ V.conj().T, cfp.hamiltonian(), atol=1e-4)
 
     def test_types(self):
-        cfp = libMcPhase.cf1ion('Pr3+', type='Alm', **self.pars_orth)
+        cfp = libmcphase.cf1ion('Pr3+', type='Alm', **self.pars_orth)
         V, E = cfp.eigensystem()
         nptest.assert_allclose(E - E[0], self.en_ref_a, atol=1e-6)
-        cfp = libMcPhase.cf1ion('Pr3+', type='Llm', **self.all_pars)
+        cfp = libmcphase.cf1ion('Pr3+', type='Llm', **self.all_pars)
         V, E = cfp.eigensystem()
         nptest.assert_allclose(E - E[0], self.en_ref_l, atol=1e-4)
+
+#    def test_physical_properties(self):
+#        # Compared to values from Mantid
+#        cf = libmcphase.cf1ion('Ce3+', B20=0.37737, B22=3.9770, B40=-0.031787, B42=-0.11611, B44=-0.12544)
+#        # Test Heat capacity calculations
+#        TCv, Cv = cf.getHeatCapacity()
+#        self.assertAlmostEqual(TCv[150], 151, 4)
+#        self.assertAlmostEqual(Cv[100], 4.2264, 3)
+#        self.assertAlmostEqual(Cv[150], 5.9218, 3)
+#        self.assertAlmostEqual(Cv[200], 5.4599, 3)
+#
+#        # Test susceptibility calculations
+#        Tchi_powder, chi_powder = cf.getSusceptibility(np.linspace(1, 300, 50), Hdir="powder")
+#        self.assertAlmostEqual(Tchi_powder[10], 62.02, 2)
+#        self.assertAlmostEqual(chi_powder[5], 1.92026e-2, 6)
+#        self.assertAlmostEqual(chi_powder[10], 1.03471e-2, 6)
+#        self.assertAlmostEqual(chi_powder[15], 0.73004e-2, 6)
+#
+#        # Test M(T) calculations
+#        Tmt_powder, mt_powder = cf.getMagneticMoment(1.0, Temperature=np.linspace(1, 300, 50), Hdir="powder", Unit="cgs")
+#        self.assertAlmostEqual(chi_powder[5], mt_powder[5], 6)
+#        self.assertAlmostEqual(chi_powder[10], mt_powder[10], 6)
+#        self.assertAlmostEqual(chi_powder[15], mt_powder[15], 6)
+#        _, invmt_powder_SI = cf.getMagneticMoment(1.0, Temperature=np.linspace(1, 300, 50), Hdir="powder", Unit="SI", Inverse=True)
+#        self.assertAlmostEqual(chi_powder[5] * 10, 1 / invmt_powder_SI[5], 2)
+#        self.assertAlmostEqual(chi_powder[10] * 10, 1 / invmt_powder_SI[10], 2)
+#        self.assertAlmostEqual(chi_powder[15] * 10, 1 / invmt_powder_SI[15], 2)
+#
+#        # Test different Hmag
+#        _, h_mag_10 = cf.getMagneticMoment(Hmag=10, Temperature=np.linspace(1, 300, 50), Hdir="powder", Unit="bohr")
+#        self.assertAlmostEqual(h_mag_10[5], 0.323607, 5)
+#        self.assertAlmostEqual(h_mag_10[10], 0.182484, 5)
+#        self.assertAlmostEqual(h_mag_10[15], 0.129909, 5)
+#        _, h_mag_5 = cf.getMagneticMoment(Hmag=5, Temperature=np.linspace(1, 300, 50), Hdir="powder", Unit="bohr")
+#        self.assertAlmostEqual(h_mag_5[5], 0.16923426, 6)
+#        self.assertAlmostEqual(h_mag_5[10], 0.09228022, 6)
+#        self.assertAlmostEqual(h_mag_5[15], 0.06525625, 6)
+#
+#        # Test M(H) calculations
+#        Hmag_SI, mag_SI = cf.getMagneticMoment(np.linspace(0, 30, 15), Temperature=10, Hdir=[0, 1, -1], Unit="SI")
+#        self.assertAlmostEqual(mag_SI[1], 1.8139, 3)
+#        self.assertAlmostEqual(mag_SI[5], 6.7859, 3)
+#        self.assertAlmostEqual(mag_SI[9], 8.2705, 3)
+#        _, mag_bohr = cf.getMagneticMoment(np.linspace(0, 30, 15), Temperature=10, Hdir=[0, 1, -1], Unit="bohr")
+#        self.assertAlmostEqual(mag_SI[1] / 5.5849, mag_bohr[1], 3)
+#        self.assertAlmostEqual(mag_SI[5] / 5.5849, mag_bohr[5], 3)
+#        self.assertAlmostEqual(mag_SI[9] / 5.5849, mag_bohr[9], 3)

--- a/tests/test_cf1ion.py
+++ b/tests/test_cf1ion.py
@@ -113,47 +113,54 @@ class cf1ionTests(unittest.TestCase):
         cf = libmcphase.cf1ion('Ce3+', **self.pp_cfpars)
         #Tchi_powder, chi_powder = cf.getSusceptibility(np.linspace(1, 300, 50), Hdir="powder")
         tt = np.linspace(1, 300, 50)
-        cx = np.array(cf.susceptibility(tt, [1., 0., 0.], 'cgs'))
-        cy = np.array(cf.susceptibility(tt, [0., 1., 0.], 'cgs'))
-        cz = np.array(cf.susceptibility(tt, [0., 0., 1.], 'cgs'))
-        chi_powder = (cx + cy + cz) / 3
+        cc = [np.array(cf.susceptibility(tt, hdir, 'cgs')) for hdir in [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]]
+        chi_powder = (cc[0] + cc[1] + cc[2]) / 3
         #self.assertAlmostEqual(Tchi_powder[10], 62.02, 2)
         self.assertAlmostEqual(chi_powder[5], 1.92026e-2, 6)
         self.assertAlmostEqual(chi_powder[10], 1.03471e-2, 6)
         self.assertAlmostEqual(chi_powder[15], 0.73004e-2, 6)
 
-#    def test_magnetisation_vs_T(self):
-#        # Test M(T) calculations
-#        cf = libmcphase.cf1ion('Ce3+', **self.pp_cfpars)
-#        Tmt_powder, mt_powder = cf.getMagneticMoment(1.0, Temperature=np.linspace(1, 300, 50), Hdir="powder", Unit="cgs")
-#        self.assertAlmostEqual(chi_powder[5], mt_powder[5], 6)
-#        self.assertAlmostEqual(chi_powder[10], mt_powder[10], 6)
-#        self.assertAlmostEqual(chi_powder[15], mt_powder[15], 6)
-#        _, invmt_powder_SI = cf.getMagneticMoment(1.0, Temperature=np.linspace(1, 300, 50), Hdir="powder", Unit="SI", Inverse=True)
-#        self.assertAlmostEqual(chi_powder[5] * 10, 1 / invmt_powder_SI[5], 2)
-#        self.assertAlmostEqual(chi_powder[10] * 10, 1 / invmt_powder_SI[10], 2)
-#        self.assertAlmostEqual(chi_powder[15] * 10, 1 / invmt_powder_SI[15], 2)
-#
-#        # Test different Hmag
-#        _, h_mag_10 = cf.getMagneticMoment(Hmag=10, Temperature=np.linspace(1, 300, 50), Hdir="powder", Unit="bohr")
-#        self.assertAlmostEqual(h_mag_10[5], 0.323607, 5)
-#        self.assertAlmostEqual(h_mag_10[10], 0.182484, 5)
-#        self.assertAlmostEqual(h_mag_10[15], 0.129909, 5)
-#        _, h_mag_5 = cf.getMagneticMoment(Hmag=5, Temperature=np.linspace(1, 300, 50), Hdir="powder", Unit="bohr")
-#        self.assertAlmostEqual(h_mag_5[5], 0.16923426, 6)
-#        self.assertAlmostEqual(h_mag_5[10], 0.09228022, 6)
-#        self.assertAlmostEqual(h_mag_5[15], 0.06525625, 6)
-#
+    def test_magnetisation_vs_T(self):
+        # Test M(T) calculations
+        cf = libmcphase.cf1ion('Ce3+', **self.pp_cfpars)
+        tt = np.linspace(1, 300, 50)
+        #Tmt_powder, mt_powder = cf.getMagneticMoment(1.0, Temperature=np.linspace(1, 300, 50), Hdir="powder", Unit="cgs")
+        cc = [np.array(cf.susceptibility(tt, hdir, 'cgs')) for hdir in [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]]
+        mm = [np.array(cf.magnetisation([1.0], hdir, tt, 'cgs')) for hdir in [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]]
+        chi_powder = (cc[0] + cc[1] + cc[2]) / 3
+        mt_powder = np.squeeze(mm[0] + mm[1] + mm[2]) / 3
+        self.assertAlmostEqual(chi_powder[5], mt_powder[5], 6)
+        self.assertAlmostEqual(chi_powder[10], mt_powder[10], 6)
+        self.assertAlmostEqual(chi_powder[15], mt_powder[15], 6)
+        #_, invmt_powder_SI = cf.getMagneticMoment(1.0, Temperature=np.linspace(1, 300, 50), Hdir="powder", Unit="SI", Inverse=True)
+        #self.assertAlmostEqual(chi_powder[5] * 10, 1 / invmt_powder_SI[5], 2)
+        #self.assertAlmostEqual(chi_powder[10] * 10, 1 / invmt_powder_SI[10], 2)
+        #self.assertAlmostEqual(chi_powder[15] * 10, 1 / invmt_powder_SI[15], 2)
+
+        # Test different Hmag
+        #_, h_mag_10 = cf.getMagneticMoment(Hmag=10, Temperature=np.linspace(1, 300, 50), Hdir="powder", Unit="bohr")
+        mm = [np.array(cf.magnetisation([10.], hdir, tt, 'bohr')) for hdir in [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]]
+        h_mag_10 = np.squeeze(mm[0] + mm[1] + mm[2]) / 3
+        self.assertAlmostEqual(h_mag_10[5], 0.323607, 5)
+        self.assertAlmostEqual(h_mag_10[10], 0.182484, 5)
+        self.assertAlmostEqual(h_mag_10[15], 0.129909, 5)
+        #_, h_mag_5 = cf.getMagneticMoment(Hmag=5, Temperature=np.linspace(1, 300, 50), Hdir="powder", Unit="bohr")
+        mm = [np.array(cf.magnetisation([5.], hdir, tt, 'bohr')) for hdir in [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]]
+        h_mag_5 = np.squeeze(mm[0] + mm[1] + mm[2]) / 3
+        self.assertAlmostEqual(h_mag_5[5], 0.16923426, 6)
+        self.assertAlmostEqual(h_mag_5[10], 0.09228022, 6)
+        self.assertAlmostEqual(h_mag_5[15], 0.06525625, 6)
+
     def test_magnetisation(self):
         # Test M(H) calculations
         cf = libmcphase.cf1ion('Ce3+', **self.pp_cfpars)
         #Hmag_SI, mag_SI = cf.getMagneticMoment(np.linspace(0, 30, 15), Temperature=10, Hdir=[0, 1, -1], Unit="SI")
-        mag_SI = cf.magnetisation(np.linspace(0, 30, 15), [0, 1, -1], 10, 'SI')
+        mag_SI = np.squeeze(cf.magnetisation(np.linspace(0, 30, 15), [0, 1, -1], [10], 'SI'))
         self.assertAlmostEqual(mag_SI[1], 1.8139, 3)
         self.assertAlmostEqual(mag_SI[5], 6.7859, 3)
         self.assertAlmostEqual(mag_SI[9], 8.2705, 3)
         #_, mag_bohr = cf.getMagneticMoment(np.linspace(0, 30, 15), Temperature=10, Hdir=[0, 1, -1], Unit="bohr")
-        mag_bohr = cf.magnetisation(np.linspace(0, 30, 15), [0, 1, -1], 10, 'bohr')
+        mag_bohr = np.squeeze(cf.magnetisation(np.linspace(0, 30, 15), [0, 1, -1], [10], 'bohr'))
         self.assertAlmostEqual(mag_SI[1] / 5.5849, mag_bohr[1], 3)
         self.assertAlmostEqual(mag_SI[5] / 5.5849, mag_bohr[5], 3)
         self.assertAlmostEqual(mag_SI[9] / 5.5849, mag_bohr[9], 3)

--- a/tests/test_cf1ion.py
+++ b/tests/test_cf1ion.py
@@ -108,15 +108,20 @@ class cf1ionTests(unittest.TestCase):
         self.assertAlmostEqual(Cv[150], 5.9218, 3)
         self.assertAlmostEqual(Cv[200], 5.4599, 3)
 
-#    def test_susceptibility(self):
-#        # Test susceptibility calculations
-#        cf = libmcphase.cf1ion('Ce3+', **self.pp_cfpars)
-#        Tchi_powder, chi_powder = cf.getSusceptibility(np.linspace(1, 300, 50), Hdir="powder")
-#        self.assertAlmostEqual(Tchi_powder[10], 62.02, 2)
-#        self.assertAlmostEqual(chi_powder[5], 1.92026e-2, 6)
-#        self.assertAlmostEqual(chi_powder[10], 1.03471e-2, 6)
-#        self.assertAlmostEqual(chi_powder[15], 0.73004e-2, 6)
-#
+    def test_susceptibility(self):
+        # Test susceptibility calculations
+        cf = libmcphase.cf1ion('Ce3+', **self.pp_cfpars)
+        #Tchi_powder, chi_powder = cf.getSusceptibility(np.linspace(1, 300, 50), Hdir="powder")
+        tt = np.linspace(1, 300, 50)
+        cx = np.array(cf.susceptibility(tt, [1., 0., 0.], 'cgs'))
+        cy = np.array(cf.susceptibility(tt, [0., 1., 0.], 'cgs'))
+        cz = np.array(cf.susceptibility(tt, [0., 0., 1.], 'cgs'))
+        chi_powder = (cx + cy + cz) / 3
+        #self.assertAlmostEqual(Tchi_powder[10], 62.02, 2)
+        self.assertAlmostEqual(chi_powder[5], 1.92026e-2, 6)
+        self.assertAlmostEqual(chi_powder[10], 1.03471e-2, 6)
+        self.assertAlmostEqual(chi_powder[15], 0.73004e-2, 6)
+
 #    def test_magnetisation_vs_T(self):
 #        # Test M(T) calculations
 #        cf = libmcphase.cf1ion('Ce3+', **self.pp_cfpars)
@@ -139,14 +144,16 @@ class cf1ionTests(unittest.TestCase):
 #        self.assertAlmostEqual(h_mag_5[10], 0.09228022, 6)
 #        self.assertAlmostEqual(h_mag_5[15], 0.06525625, 6)
 #
-#    def test_magnetisation(self):
-#        # Test M(H) calculations
-#        cf = libmcphase.cf1ion('Ce3+', **self.pp_cfpars)
-#        Hmag_SI, mag_SI = cf.getMagneticMoment(np.linspace(0, 30, 15), Temperature=10, Hdir=[0, 1, -1], Unit="SI")
-#        self.assertAlmostEqual(mag_SI[1], 1.8139, 3)
-#        self.assertAlmostEqual(mag_SI[5], 6.7859, 3)
-#        self.assertAlmostEqual(mag_SI[9], 8.2705, 3)
-#        _, mag_bohr = cf.getMagneticMoment(np.linspace(0, 30, 15), Temperature=10, Hdir=[0, 1, -1], Unit="bohr")
-#        self.assertAlmostEqual(mag_SI[1] / 5.5849, mag_bohr[1], 3)
-#        self.assertAlmostEqual(mag_SI[5] / 5.5849, mag_bohr[5], 3)
-#        self.assertAlmostEqual(mag_SI[9] / 5.5849, mag_bohr[9], 3)
+    def test_magnetisation(self):
+        # Test M(H) calculations
+        cf = libmcphase.cf1ion('Ce3+', **self.pp_cfpars)
+        #Hmag_SI, mag_SI = cf.getMagneticMoment(np.linspace(0, 30, 15), Temperature=10, Hdir=[0, 1, -1], Unit="SI")
+        mag_SI = cf.magnetisation(np.linspace(0, 30, 15), [0, 1, -1], 10, 'SI')
+        self.assertAlmostEqual(mag_SI[1], 1.8139, 3)
+        self.assertAlmostEqual(mag_SI[5], 6.7859, 3)
+        self.assertAlmostEqual(mag_SI[9], 8.2705, 3)
+        #_, mag_bohr = cf.getMagneticMoment(np.linspace(0, 30, 15), Temperature=10, Hdir=[0, 1, -1], Unit="bohr")
+        mag_bohr = cf.magnetisation(np.linspace(0, 30, 15), [0, 1, -1], 10, 'bohr')
+        self.assertAlmostEqual(mag_SI[1] / 5.5849, mag_bohr[1], 3)
+        self.assertAlmostEqual(mag_SI[5] / 5.5849, mag_bohr[5], 3)
+        self.assertAlmostEqual(mag_SI[9] / 5.5849, mag_bohr[9], 3)

--- a/tests/test_ic1ion.py
+++ b/tests/test_ic1ion.py
@@ -58,6 +58,6 @@ class ic1ionTests(unittest.TestCase):
         ref_sus = np.array([0.0377984, 0.0581256, 0.0392299, 0.0284567, 0.0221967, 0.0181698, 0.0153757, 0.0133276, 0.0117635, 0.0105307, 0.00953459])
         cfp = libmcphase.ic1ion('Pr3+', **self.pars_orth)
         sus = cfp.susceptibility(np.arange(1, 302, 30), [1, 0, 0], 'bohr')
-        nptest.assert_allclose(sus, ref_sus * 8, atol=1e-2) # Not sure where the factor of 8 comes from...
+        nptest.assert_allclose(sus, ref_sus, atol=1e-4)
         
 

--- a/tests/test_ic1ion.py
+++ b/tests/test_ic1ion.py
@@ -55,8 +55,8 @@ class ic1ionTests(unittest.TestCase):
         self.assertAlmostEqual(Cv[200], 5.4599, 3)
 
     def test_magnetisation(self):
-        # Test compared to McPhase 5.4
-        ref_mag = np.array([0, 0.299607, 0.585826, 0.848715, 1.0833, 1.28896, 1.46781, 1.62318, 1.75859, 1.87726, 1.98196])
+        # Test compared to McPhase 5.4 (using m_parallel)
+        ref_mag = np.array([0, 0.297508, 0.58146, 0.841784, 1.07343, 1.27577, 1.45094, 1.6023, 1.73344, 1.84766, 1.94775])
         cfp = libmcphase.ic1ion('Pr3+', **self.all_pars)
         mag = cfp.magnetisation(np.arange(0, 21, 2), [1, 0, 0], 1, 'bohr')
         nptest.assert_allclose(mag, ref_mag, atol=1e-4)
@@ -68,4 +68,11 @@ class ic1ionTests(unittest.TestCase):
         sus = cfp.susceptibility(np.arange(1, 302, 30), [1, 0, 0], 'bohr')
         nptest.assert_allclose(sus, ref_sus, atol=1e-4)
         
-
+    def test_magnetisation_cf(self):
+        # Test M(H) calculations
+        cf = libmcphase.ic1ion('Ce3+', B20=0.37737, B22=3.9770, B40=-0.031787, B42=-0.11611, B44=-0.12544, zeta=1e9, unit='meV')
+        #Hmag_SI, mag_SI = cf.getMagneticMoment(np.linspace(0, 30, 15), Temperature=10, Hdir=[0, 1, -1], Unit="SI")
+        mag_SI = cf.magnetisation(np.linspace(0, 30, 15), [0, 1, -1], 10, 'SI')
+        self.assertAlmostEqual(mag_SI[1], 1.8139, 2)
+        self.assertAlmostEqual(mag_SI[5], 6.7859, 2)
+        self.assertAlmostEqual(mag_SI[9], 8.2705, 2)

--- a/tests/test_ic1ion.py
+++ b/tests/test_ic1ion.py
@@ -46,9 +46,17 @@ class ic1ionTests(unittest.TestCase):
         nptest.assert_allclose(E, self.en_refi, atol=1e-2)
         nptest.assert_allclose(V @ np.diag(E) @ V.conj().T, cfp.hamiltonian(), atol=1e-4)
 
+    def test_heatcapacity(self):
+        # Test compared to Mantid in LS limit
+        cf = libmcphase.ic1ion('Ce3+', B20=0.37737, B22=3.9770, B40=-0.031787, B42=-0.11611, B44=-0.12544, zeta=1e9, unit='meV')
+        Cv = cf.heatcapacity(np.linspace(1,300,300))
+        self.assertAlmostEqual(Cv[100], 4.2264, 3)
+        self.assertAlmostEqual(Cv[150], 5.9218, 3)
+        self.assertAlmostEqual(Cv[200], 5.4599, 3)
+
     def test_magnetisation(self):
         # Test compared to McPhase 5.4
-        ref_mag = np.array([3.35996e-13, 0.299607, 0.585826, 0.848715, 1.0833, 1.28896, 1.46781, 1.62318, 1.75859, 1.87726, 1.98196])
+        ref_mag = np.array([0, 0.299607, 0.585826, 0.848715, 1.0833, 1.28896, 1.46781, 1.62318, 1.75859, 1.87726, 1.98196])
         cfp = libmcphase.ic1ion('Pr3+', **self.all_pars)
         mag = cfp.magnetisation(np.arange(0, 21, 2), [1, 0, 0], 1, 'bohr')
         nptest.assert_allclose(mag, ref_mag, atol=1e-4)

--- a/tests/test_ic1ion.py
+++ b/tests/test_ic1ion.py
@@ -83,24 +83,24 @@ class ic1ionTests(unittest.TestCase):
         # Test susceptibility / M(T) calculations in the LS-limit
         cf = libmcphase.ic1ion('Ce3+', **self.pp_cfpars)
         tt = np.linspace(1, 300, 50)
-        cc = [np.array(cf.susceptibility(tt, hdir, 'cgs')) for hdir in [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]]
+        cc = [cf.susceptibility(tt, hdir, 'cgs') for hdir in [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]]
         chi_powder = (cc[0] + cc[1] + cc[2]) / 3
         self.assertAlmostEqual(chi_powder[5], 1.92026e-2, 3)
         self.assertAlmostEqual(chi_powder[10], 1.03471e-2, 3)
         self.assertAlmostEqual(chi_powder[15], 0.73004e-2, 3)
         # Test susceptibility and M(T) calculations similar in the limit of small applied fields
-        mm = [np.array(cf.magnetisation([1.0], hdir, tt, 'cgs')) for hdir in [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]]
+        mm = [cf.magnetisation([1.0], hdir, tt, 'cgs') for hdir in [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]]
         mt_powder = np.squeeze(mm[0] + mm[1] + mm[2]) / 3
         self.assertAlmostEqual(chi_powder[5], mt_powder[5], 3)
         self.assertAlmostEqual(chi_powder[10], mt_powder[10], 3)
         self.assertAlmostEqual(chi_powder[15], mt_powder[15], 3)
         # Test different Hmag
-        mm = [np.array(cf.magnetisation([10.], hdir, tt, 'bohr')) for hdir in [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]]
+        mm = [cf.magnetisation([10.], hdir, tt, 'bohr') for hdir in [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]]
         h_mag_10 = np.squeeze(mm[0] + mm[1] + mm[2]) / 3
         self.assertAlmostEqual(h_mag_10[5], 0.323607, 3)
         self.assertAlmostEqual(h_mag_10[10], 0.182484, 3)
         self.assertAlmostEqual(h_mag_10[15], 0.129909, 3)
-        mm = [np.array(cf.magnetisation([5.], hdir, tt, 'bohr')) for hdir in [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]]
+        mm = [cf.magnetisation([5.], hdir, tt, 'bohr') for hdir in [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]]
         h_mag_5 = np.squeeze(mm[0] + mm[1] + mm[2]) / 3
         self.assertAlmostEqual(h_mag_5[5], 0.16923426, 3)
         self.assertAlmostEqual(h_mag_5[10], 0.09228022, 3)

--- a/tests/test_ic1ion.py
+++ b/tests/test_ic1ion.py
@@ -1,0 +1,63 @@
+import libmcphase
+import unittest
+import numpy as np
+import numpy.testing as nptest
+
+class ic1ionTests(unittest.TestCase):
+    # Eigenvalues from McPhase 5.4
+    en_refr = np.array([-1400.18, -1399.68, -1398.16, -1397.99, -1395.58, -1394.96, -1394.66, -1393, -1392.79, -1138.31, -1138.08, -1136.94, -1136.62,
+                        -1134.23, -1134.15, -1133.97, -1133.61, -1133.59, -1132.48, -1132.38, -866.993, -866.41, -865.065, -864.368, -861.593, -861.056,
+                        -861.049, -860.474, -859.914, -859.474, -858.926, -858.058, -856.903, -790.393, -789.612, -789.31, -789.161, -788.855, -616.178,
+                        -615.661, -615.332, -614.225, -614.118, -614.007, -613.522, -558.719, -557.832, -557.34, -556.635, -556.411, -555.567, -555.043,
+                        -554.843, -554.372, -192.949, -189.563, -188.162, -187.462, -186.38, -186.378, -184.65, -184.329, -181.205, 688.838, 692.736,
+                        693.247, 694.493, 695.46, 1161.97, 1239.94, 1241.31, 1242.12, 1242.19, 1242.47, 1242.77, 1243.14, 1247.49, 1247.63, 1248.64,
+                        1249.32, 1249.98, 1250.73, 1251.11, 1252.69, 1252.71, 1392.6, 1393.44, 1394.54, 1395.23, 1395.74, 4395.67])
+    en_refi = np.array([-1401.95, -1400, -1399.35, -1397.6, -1397.35, -1394.78, -1393.62, -1391.6, -1391.2, -1138.68, -1138.51, -1137.76, -1137.14,
+                        -1136.26, -1135.27, -1133.49, -1133.13, -1132.8, -1130.93, -1130.77, -867.828, -866.929, -865.631, -865.456, -864.899, -863.497,
+                        -861.647, -859.534, -859.274, -858.897, -857.456, -855.493, -854.43, -790.395, -789.715, -789.491, -788.752, -788.509, -616.586,
+                        -615.789, -615.547, -614.621, -613.821, -613.495, -612.842, -559.522, -558.528, -558.2, -557.096, -555.609, -555.275, -554.533,
+                        -554.178, -553.457, -194.468, -191.231, -190.087, -188.514, -186.898, -184.581, -183.756, -181.359, -180.12, 687.351, 691.495,
+                        694.211, 695.196, 696.31, 1161.97, 1238.78, 1238.85, 1239.82, 1241.21, 1242.38, 1243.71, 1244, 1246.92, 1247.8, 1248.35,
+                        1249.18, 1250.33, 1251.35, 1252.72, 1254.41, 1254.74, 1392.24, 1393.39, 1394.75, 1395.45, 1395.9, 4395.7])
+
+    pars_orth = {'B20':9.1381e-04, 'B22':1.0386e-01, 
+                 'B40':-7.2952e-04, 'B42':-3.3059e-03, 'B44':-4.5648e-03, 
+                 'B60':-2.1369e-05, 'B62':8.8995e-05, 'B64':4.7701e-04, 'B66':3.9818e-04}
+    pars_real = dict(pars_orth, **{'B21':1.0579e-01, 'B41':6.4828e-03, 'B43':1.5821e-02, 'B61':4.3678e-04, 'B63':1.0380e-04, 'B65':-1.1485e-03})
+    pars_imag = {'B22S':-6.6761e-02, 'B21S':2.3224e-02, 
+                 'B44S':-8.1745e-03, 'B43S':-2.3769e-03, 'B42S':4.8620e-03, 'B41S':6.6729e-03, 
+                 'B66S':-6.6456e-04, 'B65S':8.0453e-04, 'B64S':3.4691e-04, 'B63S':5.1962e-04, 'B62S':-1.2112e-04, 'B61S':3.5266e-05}
+    all_pars = dict(pars_real, **pars_imag)
+
+    def test_creation_and_diagonalisation(self):
+        with self.assertRaises(RuntimeError):   # Can only be constructed from ion name
+            cfp = libmcphase.ic1ion(2.5)
+        with self.assertRaises(RuntimeError):   # Unknown ion name
+            cfp = libmcphase.ic1ion('O2-')
+        # Random parameters, compared to results from McPhase normal
+        cfp = libmcphase.ic1ion('Pr3+', **self.pars_real)
+        V, E = cfp.eigensystem()
+        nptest.assert_allclose(E, self.en_refr, atol=1e-2)
+        nptest.assert_allclose(V @ np.diag(E) @ V.conj().T, cfp.hamiltonian(), atol=1e-4)
+
+    def test_all_parameters(self):
+        cfp = libmcphase.ic1ion('Pr3+', **self.all_pars)
+        V, E = cfp.eigensystem()
+        nptest.assert_allclose(E, self.en_refi, atol=1e-2)
+        nptest.assert_allclose(V @ np.diag(E) @ V.conj().T, cfp.hamiltonian(), atol=1e-4)
+
+    def test_magnetisation(self):
+        # Test compared to McPhase 5.4
+        ref_mag = np.array([3.35996e-13, 0.299607, 0.585826, 0.848715, 1.0833, 1.28896, 1.46781, 1.62318, 1.75859, 1.87726, 1.98196])
+        cfp = libmcphase.ic1ion('Pr3+', **self.all_pars)
+        mag = cfp.magnetisation(np.arange(0, 21, 2), [1, 0, 0], 1, 'bohr')
+        nptest.assert_allclose(mag, ref_mag, atol=1e-4)
+
+    def test_susceptibility(self):
+        # Test compared to McPhase 5.4 magnetisation vs T at 1T
+        ref_sus = np.array([0.0377984, 0.0581256, 0.0392299, 0.0284567, 0.0221967, 0.0181698, 0.0153757, 0.0133276, 0.0117635, 0.0105307, 0.00953459])
+        cfp = libmcphase.ic1ion('Pr3+', **self.pars_orth)
+        sus = cfp.susceptibility(np.arange(1, 302, 30), [1, 0, 0], 'bohr')
+        nptest.assert_allclose(sus, ref_sus * 8, atol=1e-2) # Not sure where the factor of 8 comes from...
+        
+

--- a/tests/test_ic1ion.py
+++ b/tests/test_ic1ion.py
@@ -19,6 +19,8 @@ class ic1ionTests(unittest.TestCase):
                         -554.178, -553.457, -194.468, -191.231, -190.087, -188.514, -186.898, -184.581, -183.756, -181.359, -180.12, 687.351, 691.495,
                         694.211, 695.196, 696.31, 1161.97, 1238.78, 1238.85, 1239.82, 1241.21, 1242.38, 1243.71, 1244, 1246.92, 1247.8, 1248.35,
                         1249.18, 1250.33, 1251.35, 1252.72, 1254.41, 1254.74, 1392.24, 1393.39, 1394.75, 1395.45, 1395.9, 4395.7])
+    soc_en_ref = [-344.537, -242.765, -232.284, 53.757, 78.024, 109.005, 110.101, 124.149, 176.359, 348.294, 445.594, 473.504, 474.274]
+    slat_en_ref = [-1088.304, -568.177, -343.142, 717.946, 1241.54, 1287.725, 4363.09]
 
     pars_orth = {'B20':9.1381e-04, 'B22':1.0386e-01, 
                  'B40':-7.2952e-04, 'B42':-3.3059e-03, 'B44':-4.5648e-03, 
@@ -30,6 +32,16 @@ class ic1ionTests(unittest.TestCase):
     all_pars = dict(pars_real, **pars_imag)
 
     pp_cfpars = {'B20':0.37737, 'B22':3.9770, 'B40':-0.031787, 'B42':-0.11611, 'B44':-0.12544, 'zeta':1.e9}
+
+    def test_soc(self):
+        cfp = libmcphase.ic1ion('Pr3+', slater=[0,0,0,0], zeta=100)
+        Esoc = np.sort(np.unique(np.round(cfp.eigensystem()[1], decimals=3)))
+        nptest.assert_allclose(Esoc, self.soc_en_ref, atol=1e-3)
+
+    def test_slater(self):
+        cfp = libmcphase.ic1ion('Pr3+', zeta=0)
+        Eslat = np.sort(np.unique(np.round(cfp.eigensystem()[1], decimals=3)))
+        nptest.assert_allclose(Eslat, self.slat_en_ref, atol=1e-3)
 
     def test_creation_and_diagonalisation(self):
         with self.assertRaises(RuntimeError):   # Can only be constructed from ion name


### PR DESCRIPTION
* Refactors the `magnetisation` and `susceptibility` calculations from being within `ic1ion::` to a separate class `physprop::` which is inherited by both `ic1ion::` and `cf1ion::`.
* Changes the calculation of the `magnetisation` from outputting the root-mean-square of Mx/My/Mz to outputting M_parallel (the component of the induced moment parallel to the applied field), in agreement with the behaviour of FOCUS/Mantid.
* Add `heatcapacity` calculation.
* Add tests to compare results with output of McPhase 5.4 and Mantid.
* Add tests for `ic1ion` with `zeta=1e9` to compare with `cf1ion` results.